### PR TITLE
fix(#192): send payment to escrow contract, not platform fee account

### DIFF
--- a/src/hooks/usePayment.ts
+++ b/src/hooks/usePayment.ts
@@ -116,8 +116,8 @@ export const usePayment = (details: PaymentDetails) => {
     setState(prev => ({ ...prev, step: 'processing', isSubmitting: true, error: undefined }));
 
     try {
-      // Send payment to escrow account (this would be the platform's escrow account)
-      const escrowAccount = STELLAR_CONFIG.platformFeeAccount; // In real implementation, this would be generated per session
+      // Send payment to the per-session escrow contract
+      const escrowAccount = details.escrowContractId ?? STELLAR_CONFIG.contractId;
       
       const transaction = await sendPayment(
         escrowAccount,

--- a/src/types/payment.types.ts
+++ b/src/types/payment.types.ts
@@ -32,6 +32,7 @@ export interface PaymentDetails {
   sessionId?: string;
   sessionTopic: string;
   amount: number; // Base amount in USD or equivalent
+  escrowContractId?: string; // Per-session escrow contract address; falls back to STELLAR_CONFIG.contractId
 }
 
 // ── Escrow Types ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
- Replace STELLAR_CONFIG.platformFeeAccount with per-session escrow contract address in processPayment
- Derive escrow destination from details.escrowContractId, falling back to STELLAR_CONFIG.contractId
- Add optional escrowContractId field to PaymentDetails type so booking context can supply the per-session contract address
- platformFeeAccount remains available for fee collection only

closes #192 