### PR TITLE
[#292] Dispute Filing Form Must Use transaction_id, Not booking_id

### DIFF
--- a/src/components/payment/EscrowStatus.tsx
+++ b/src/components/payment/EscrowStatus.tsx
@@ -1,6 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import type { EscrowContract, EscrowStatus } from '../../types/payment.types';
 
+const disputeStatusLabelMap: Record<string, string> = {
+  open: 'Under Review',
+  under_review: 'Escalated',
+  resolved: 'Resolved',
+};
+
+const getDisputeStatusLabel = (status: string): string => {
+  return disputeStatusLabelMap[status] ?? status;
+};
+
 interface EscrowStatusProps {
   escrow: EscrowContract;
   userRole: 'learner' | 'mentor';
@@ -177,7 +187,7 @@ const EscrowStatus: React.FC<EscrowStatusProps> = ({
                 Dispute Details
               </p>
               <span className={`text-[10px] px-2 py-1 rounded-full font-bold ${escrow.dispute.status === 'resolved' ? 'bg-gray-200 text-gray-600' : 'bg-red-200 text-red-700'}`}>
-                {escrow.dispute.status === 'resolved' ? 'Resolved' : 'Pending'}
+                {getDisputeStatusLabel(escrow.dispute.status)}
               </span>
             </div>
             <p className="text-sm font-medium text-gray-700 capitalize">

--- a/src/components/session/SessionHistoryCard.tsx
+++ b/src/components/session/SessionHistoryCard.tsx
@@ -1,5 +1,6 @@
 import Badge from '../ui/Badge';
 import Button from '../ui/Button';
+import Tooltip from '../ui/Tooltip';
 import type { BookingRecord } from '../../hooks/useBookingHistory';
 import type { SessionStatus } from '../../types';
 
@@ -21,13 +22,14 @@ interface Props {
   booking: BookingRecord;
   inDisputeWindow: boolean;
   onLeaveReview: (id: string) => void;
-  onOpenDispute: (id: string) => void;
+  onOpenDispute: (id: string, transactionId?: string | null) => void;
   onViewReceipt: (id: string) => void;
 }
 
 export default function SessionHistoryCard({ booking, inDisputeWindow, onLeaveReview, onOpenDispute, onViewReceipt }: Props) {
   const badge = STATUS_BADGE[booking.status];
   const isPast = booking.status === 'completed' || booking.status === 'cancelled';
+  const canOpenDispute = Boolean(booking.transaction_id);
 
   return (
     <div className="bg-white rounded-xl border border-gray-200 p-4 hover:shadow-sm transition-shadow">
@@ -87,10 +89,30 @@ export default function SessionHistoryCard({ booking, inDisputeWindow, onLeaveRe
                 </Button>
               )}
               {booking.status === 'completed' && inDisputeWindow && (
-                <Button size="sm" variant="outline" onClick={() => onOpenDispute(booking.id)}
-                  className="text-red-600 border-red-200 hover:bg-red-50">
-                  🚩 Open Dispute
-                </Button>
+                canOpenDispute ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onOpenDispute(booking.id, booking.transaction_id ?? null)}
+                    className="text-red-600 border-red-200 hover:bg-red-50"
+                  >
+                    🚩 Open Dispute
+                  </Button>
+                ) : (
+                  <Tooltip content="A dispute can only be opened after payment is confirmed" position="top">
+                    <span className="inline-flex">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => onOpenDispute(booking.id, booking.transaction_id ?? null)}
+                        disabled
+                        className="text-red-600 border-red-200 hover:bg-red-50"
+                      >
+                        🚩 Open Dispute
+                      </Button>
+                    </span>
+                  </Tooltip>
+                )
               )}
               {booking.receiptUrl && (
                 <Button size="sm" variant="ghost" onClick={() => onViewReceipt(booking.id)}>

--- a/src/hooks/useBookingHistory.ts
+++ b/src/hooks/useBookingHistory.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import type { Session, SessionStatus } from '../types';
+import { getBookingTransactionId } from '../services/dispute.service';
 
 // ─── Extended booking type ────────────────────────────────────────────────────
 
@@ -13,6 +14,7 @@ export interface BookingRecord extends Session {
   /** ISO string of when the session ended; dispute window = 72 h after */
   endedAt?: string;
   receiptUrl?: string;
+  transaction_id?: string | null;
 }
 
 export type TabKey = 'upcoming' | 'past';
@@ -51,21 +53,21 @@ const MOCK: BookingRecord[] = [
     mentorName: 'Nora Chen', mentorAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Nora',
     learnerName: 'You',
     scheduledAt: d(-3), duration: 60, status: 'completed', price: 80, asset: 'USDC',
-    endedAt: d(-3), hasReview: false, receiptUrl: '#',
+    endedAt: d(-3), hasReview: false, receiptUrl: '#', transaction_id: 'txn-b3',
   },
   {
     id: 'b4', mentorId: 'm1', learnerId: 'l1',
     mentorName: 'Aisha Bello', mentorAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Aisha',
     learnerName: 'You',
     scheduledAt: d(-10), duration: 90, status: 'completed', price: 120, asset: 'XLM',
-    endedAt: d(-10), hasReview: true, receiptUrl: '#',
+    endedAt: d(-10), hasReview: true, receiptUrl: '#', transaction_id: 'txn-b4',
   },
   {
     id: 'b5', mentorId: 'm4', learnerId: 'l1',
     mentorName: 'Kwame Asante', mentorAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Kwame',
     learnerName: 'You',
     scheduledAt: d(-15), duration: 30, status: 'completed', price: 40, asset: 'USDC',
-    endedAt: d(-15), hasReview: false, receiptUrl: '#',
+    endedAt: d(-15), hasReview: false, receiptUrl: '#', transaction_id: null,
   },
   // Past – cancelled
   {
@@ -105,6 +107,7 @@ export function useBookingHistory() {
   const [filters, setFilters] = useState<HistoryFilters>({ status: 'all', dateFrom: '', dateTo: '' });
   const [page, setPage] = useState(1);
   const [isLoading] = useState(false);
+  const [transactionIdsByBooking, setTransactionIdsByBooking] = useState<Record<string, string | null>>({});
 
   const updateFilter = useCallback(<K extends keyof HistoryFilters>(key: K, value: HistoryFilters[K]) => {
     setFilters((f) => ({ ...f, [key]: value }));
@@ -138,6 +141,16 @@ export function useBookingHistory() {
   }, [tab, filters]);
 
   const paginated = useMemo(() => filtered.slice(0, page * PAGE_SIZE), [filtered, page]);
+  const bookingsWithTransactions = useMemo(
+    () => paginated.map((booking) => ({
+      ...booking,
+      transaction_id:
+        transactionIdsByBooking[booking.id] !== undefined
+          ? transactionIdsByBooking[booking.id]
+          : (booking.transaction_id ?? null),
+    })),
+    [paginated, transactionIdsByBooking],
+  );
   const hasMore = paginated.length < filtered.length;
 
   const loadMore = useCallback(() => setPage((p) => p + 1), []);
@@ -148,10 +161,56 @@ export function useBookingHistory() {
     return hoursElapsed <= DISPUTE_WINDOW_HOURS;
   }, []);
 
+  useEffect(() => {
+    let mounted = true;
+
+    const hydrateTransactionIds = async () => {
+      const completedWithoutHydratedTx = bookingsWithTransactions.filter(
+        (booking) =>
+          booking.status === 'completed' &&
+          booking.transaction_id === undefined &&
+          transactionIdsByBooking[booking.id] === undefined,
+      );
+
+      if (completedWithoutHydratedTx.length === 0) {
+        return;
+      }
+
+      const updates = await Promise.all(
+        completedWithoutHydratedTx.map(async (booking) => {
+          try {
+            const detail = await getBookingTransactionId(booking.id);
+            return [booking.id, detail.transaction_id] as const;
+          } catch {
+            return [booking.id, null] as const;
+          }
+        }),
+      );
+
+      if (!mounted || updates.length === 0) {
+        return;
+      }
+
+      setTransactionIdsByBooking((prev) => {
+        const next = { ...prev };
+        updates.forEach(([bookingId, transactionId]) => {
+          next[bookingId] = transactionId;
+        });
+        return next;
+      });
+    };
+
+    void hydrateTransactionIds();
+
+    return () => {
+      mounted = false;
+    };
+  }, [bookingsWithTransactions, transactionIdsByBooking]);
+
   return {
     tab, switchTab,
     filters, updateFilter,
-    bookings: paginated,
+    bookings: bookingsWithTransactions,
     totalCount: filtered.length,
     hasMore,
     loadMore,

--- a/src/services/__tests__/dispute.service.test.ts
+++ b/src/services/__tests__/dispute.service.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import api from '../api';
+import {
+  getBookingTransactionId,
+  getDisputeStatusLabel,
+  listDisputes,
+  uploadDisputeEvidence,
+} from '../dispute.service';
+
+vi.mock('../api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe('dispute.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads transaction_id from booking session payload', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      data: {
+        data: {
+          id: 'booking-1',
+          session: {
+            transaction_id: 'txn-123',
+          },
+        },
+      },
+    } as never);
+
+    const result = await getBookingTransactionId('booking-1');
+
+    expect(api.get).toHaveBeenCalledWith('/bookings/booking-1');
+    expect(result.transaction_id).toBe('txn-123');
+  });
+
+  it('returns null transaction_id when payment is not confirmed', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      data: {
+        data: {
+          id: 'booking-2',
+          session: {
+            transaction_id: null,
+          },
+        },
+      },
+    } as never);
+
+    const result = await getBookingTransactionId('booking-2');
+
+    expect(result.transaction_id).toBeNull();
+  });
+
+  it('handles flat disputes list response without pagination metadata', async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      data: {
+        data: [
+          { id: 'd1', transaction_id: 'tx-1', status: 'open' },
+          { id: 'd2', transaction_id: 'tx-2', status: 'under_review' },
+        ],
+      },
+    } as never);
+
+    const result = await listDisputes();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('d1');
+  });
+
+  it('maps dispute statuses to required labels', () => {
+    expect(getDisputeStatusLabel('open')).toBe('Under Review');
+    expect(getDisputeStatusLabel('under_review')).toBe('Escalated');
+    expect(getDisputeStatusLabel('resolved')).toBe('Resolved');
+  });
+
+  it('uploads file first and then posts evidence payload with file_url', async () => {
+    vi.mocked(api.post)
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            file_url: 'https://storage.example.com/evidence.png',
+          },
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        data: {
+          data: { id: 'evidence-1' },
+        },
+      } as never);
+
+    const file = new File(['proof'], 'proof.png', { type: 'image/png' });
+
+    await uploadDisputeEvidence({
+      disputeId: 'dispute-1',
+      text_content: 'Attached screenshot proof.',
+      file,
+    });
+
+    expect(api.post).toHaveBeenNthCalledWith(
+      1,
+      '/uploads',
+      expect.any(FormData),
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    );
+
+    expect(api.post).toHaveBeenNthCalledWith(
+      2,
+      '/disputes/dispute-1/evidence',
+      {
+        text_content: 'Attached screenshot proof.',
+        file_url: 'https://storage.example.com/evidence.png',
+      },
+    );
+  });
+});

--- a/src/services/dispute.service.ts
+++ b/src/services/dispute.service.ts
@@ -1,0 +1,133 @@
+import api from './api';
+
+export type DisputeStatus = 'open' | 'under_review' | 'resolved' | string;
+
+export interface DisputeRecord {
+  id: string;
+  transaction_id: string;
+  reason: string;
+  description: string;
+  status: DisputeStatus;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CreateDisputePayload {
+  transaction_id: string;
+  reason: string;
+  description: string;
+}
+
+export interface BookingDetailTransaction {
+  transaction_id: string | null;
+}
+
+export const DISPUTE_STATUS_LABELS: Record<string, string> = {
+  open: 'Under Review',
+  under_review: 'Escalated',
+  resolved: 'Resolved',
+};
+
+export function getDisputeStatusLabel(status: string): string {
+  return DISPUTE_STATUS_LABELS[status] ?? status;
+}
+
+function pickTransactionId(raw: unknown): string | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const record = raw as Record<string, unknown>;
+
+  const direct = record.transaction_id;
+  if (typeof direct === 'string' && direct.trim().length > 0) {
+    return direct;
+  }
+
+  const session = record.session;
+  if (session && typeof session === 'object') {
+    const nested = (session as Record<string, unknown>).transaction_id;
+    if (typeof nested === 'string' && nested.trim().length > 0) {
+      return nested;
+    }
+    if (nested === null) {
+      return null;
+    }
+  }
+
+  if (direct === null) {
+    return null;
+  }
+
+  return null;
+}
+
+export async function getBookingTransactionId(
+  bookingId: string,
+): Promise<BookingDetailTransaction> {
+  const { data } = await api.get(`/bookings/${bookingId}`);
+  const payload = (data?.data ?? data) as unknown;
+
+  return {
+    transaction_id: pickTransactionId(payload),
+  };
+}
+
+export async function createDispute(
+  payload: CreateDisputePayload,
+): Promise<DisputeRecord> {
+  const { data } = await api.post('/disputes', payload);
+  return (data?.data ?? data) as DisputeRecord;
+}
+
+export async function listDisputes(): Promise<DisputeRecord[]> {
+  const { data } = await api.get('/disputes');
+  const payload = (data?.data ?? data) as unknown;
+
+  if (Array.isArray(payload)) {
+    return payload as DisputeRecord[];
+  }
+
+  if (payload && typeof payload === 'object') {
+    const maybeNested = (payload as Record<string, unknown>).data;
+    if (Array.isArray(maybeNested)) {
+      return maybeNested as DisputeRecord[];
+    }
+  }
+
+  return [];
+}
+
+export async function uploadDisputeFile(file: File): Promise<string> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const { data } = await api.post('/uploads', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  const payload = (data?.data ?? data) as Record<string, unknown>;
+  const fileUrl = payload.file_url ?? payload.url;
+  if (typeof fileUrl !== 'string' || fileUrl.trim().length === 0) {
+    throw new Error('Upload did not return a file URL');
+  }
+
+  return fileUrl;
+}
+
+export async function uploadDisputeEvidence(params: {
+  disputeId: string;
+  text_content: string;
+  file: File;
+}): Promise<unknown> {
+  const file_url = await uploadDisputeFile(params.file);
+  const payload = {
+    text_content: params.text_content,
+    file_url,
+  };
+
+  const { data } = await api.post(`/disputes/${params.disputeId}/evidence`, payload);
+  return data?.data ?? data;
+}


### PR DESCRIPTION
## Summary
- add a dispute service that fetches booking transaction ids from booking detail responses and submits dispute payloads with `transaction_id`
- guard the Session History "Open Dispute" action when `transaction_id` is missing and show required tooltip text
- handle dispute list responses as flat `{ data: [] }` arrays and add dispute status label mapping
- implement evidence upload flow that uploads file first, then sends `{ text_content, file_url }` to `POST /disputes/:id/evidence`
- add focused unit tests for transaction-id extraction, flat dispute list handling, status labels, and evidence payload sequencing

## Validation
- `npx vitest run src/services/__tests__/dispute.service.test.ts`
- `npm run build` *(currently fails due many pre-existing unrelated TypeScript errors in the repo)*

Closes #292