### PR TITLE
feat(admin): implement offset pagination and analytics CSV export (#3…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,12 @@ const Settings = lazy(() => import('./pages/Settings'));
 const MFAChallengeScreen = lazy(() => import('./pages/MFAChallengeScreen'));
 const Messages = lazy(() => import('./pages/Messages'));
 const AdminAnalytics = lazy(() => import('./components/admin/AdminAnalytics'));
+const AdminUsers = lazy(() => import('./components/admin/AdminUsers'));
+const AdminTransactions = lazy(() => import('./components/admin/AdminTransactions'));
+const AdminSessions = lazy(() => import('./components/admin/AdminSessions'));
+const AdminPayments = lazy(() => import('./components/admin/AdminPayments'));
+const AdminDisputes = lazy(() => import('./components/admin/AdminDisputes'));
+const AdminLogs = lazy(() => import('./components/admin/AdminLogs'));
 
 // Loading component for Suspense
 const PageLoader = () => (
@@ -83,8 +89,8 @@ function AppRoutes() {
                 />
 
             {/* Admin routes */}
-            <Route 
-              path="/admin/analytics" 
+            <Route
+              path="/admin/analytics"
               element={
                 <ProtectedRoute>
                   <RoleBasedRoute auth={auth} allowedRoles={['admin']}>
@@ -93,7 +99,79 @@ function AppRoutes() {
                     </DashboardLayout>
                   </RoleBasedRoute>
                 </ProtectedRoute>
-              } 
+              }
+            />
+            <Route
+              path="/admin/users"
+              element={
+                <ProtectedRoute>
+                  <RoleBasedRoute auth={auth} allowedRoles={['admin']}>
+                    <DashboardLayout>
+                      <AdminUsers />
+                    </DashboardLayout>
+                  </RoleBasedRoute>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/transactions"
+              element={
+                <ProtectedRoute>
+                  <RoleBasedRoute auth={auth} allowedRoles={['admin']}>
+                    <DashboardLayout>
+                      <AdminTransactions />
+                    </DashboardLayout>
+                  </RoleBasedRoute>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/sessions"
+              element={
+                <ProtectedRoute>
+                  <RoleBasedRoute auth={auth} allowedRoles={['admin']}>
+                    <DashboardLayout>
+                      <AdminSessions />
+                    </DashboardLayout>
+                  </RoleBasedRoute>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/payments"
+              element={
+                <ProtectedRoute>
+                  <RoleBasedRoute auth={auth} allowedRoles={['admin']}>
+                    <DashboardLayout>
+                      <AdminPayments />
+                    </DashboardLayout>
+                  </RoleBasedRoute>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/disputes"
+              element={
+                <ProtectedRoute>
+                  <RoleBasedRoute auth={auth} allowedRoles={['admin']}>
+                    <DashboardLayout>
+                      <AdminDisputes />
+                    </DashboardLayout>
+                  </RoleBasedRoute>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/logs"
+              element={
+                <ProtectedRoute>
+                  <RoleBasedRoute auth={auth} allowedRoles={['admin']}>
+                    <DashboardLayout>
+                      <AdminLogs />
+                    </DashboardLayout>
+                  </RoleBasedRoute>
+                </ProtectedRoute>
+              }
             />
 
             {/* Settings Redirect */}

--- a/src/components/admin/AdminAnalytics.tsx
+++ b/src/components/admin/AdminAnalytics.tsx
@@ -6,7 +6,7 @@ import BarChart from '../charts/BarChart';
 import PieChart from '../charts/PieChart';
 import ChartContainer from '../charts/ChartContainer';
 import { TableSkeletonLoader } from '../animations/SkeletonLoader';
-import { exportToCSV } from '../../utils/export.utils';
+import { exportAnalyticsCSV } from '../../utils/analyticsExport.utils';
 import { CHART_COLORS } from '../../utils/chart.utils';
 import apiClient from '../../services/api.client';
 
@@ -30,6 +30,7 @@ export const AdminAnalytics: React.FC = () => {
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [exportLoading, setExportLoading] = useState<'revenue' | 'sessions' | null>(null);
 
   const fetchAnalytics = async (range: TimeRange) => {
     setLoading(true);
@@ -107,18 +108,19 @@ export const AdminAnalytics: React.FC = () => {
     fetchAnalytics(timeRange);
   }, [timeRange]);
 
-  const handleExportCSV = (type: 'revenue' | 'sessions') => {
+  const handleExportCSV = async (type: 'revenue' | 'sessions') => {
     if (!data) return;
-    
-    if (type === 'revenue') {
-      const headers = ['Date', 'Revenue (USD)'];
-      const rows = data.revenueData.map(d => [d.date, d.revenue]);
-      exportToCSV('revenue_analytics', headers, rows);
-    } else {
-      const headers = ['Date', 'Sessions'];
-      // Assuming sessions growth follows a similar pattern for export
-      const rows = data.revenueData.map(d => [d.date, Math.floor(d.revenue / 50)]);
-      exportToCSV('sessions_analytics', headers, rows);
+
+    setExportLoading(type);
+    try {
+      const endpoint = type === 'revenue' ? '/admin/analytics/revenue' : '/admin/analytics/sessions';
+      const filename = `${type}_analytics_${timeRange}.csv`;
+      await exportAnalyticsCSV(endpoint, timeRange, filename);
+    } catch (err) {
+      console.error('Export failed:', err);
+      setError(err instanceof Error ? err.message : 'Export failed. Please try again.');
+    } finally {
+      setExportLoading(null);
     }
   };
 
@@ -187,10 +189,11 @@ export const AdminAnalytics: React.FC = () => {
           <div className="absolute top-6 right-6">
             <button
               onClick={() => handleExportCSV('revenue')}
-              className="flex items-center gap-2 text-xs font-medium text-stellar hover:text-stellar-dark transition-colors"
+              disabled={exportLoading === 'revenue'}
+              className="flex items-center gap-2 text-xs font-medium text-stellar hover:text-stellar-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Download size={14} />
-              Export CSV
+              {exportLoading === 'revenue' ? 'Exporting...' : 'Export CSV'}
             </button>
           </div>
           <LineChart
@@ -207,6 +210,16 @@ export const AdminAnalytics: React.FC = () => {
           isLoading={loading}
           error={error}
         >
+          <div className="absolute top-6 right-6">
+            <button
+              onClick={() => handleExportCSV('sessions')}
+              disabled={exportLoading === 'sessions'}
+              className="flex items-center gap-2 text-xs font-medium text-stellar hover:text-stellar-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Download size={14} />
+              {exportLoading === 'sessions' ? 'Exporting...' : 'Export CSV'}
+            </button>
+          </div>
           <BarChart
             data={data?.userGrowthData ?? []}
             xKey="date"

--- a/src/components/admin/AdminDisputes.tsx
+++ b/src/components/admin/AdminDisputes.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from 'react';
+import { AdminTable } from './AdminTable';
+import { AdminDispute, AdminListResponse } from '../../types/admin.types';
+import apiClient from '../../services/api.client';
+
+const AdminDisputes: React.FC = () => {
+  const [data, setData] = useState<AdminDispute[]>([]);
+  const [meta, setMeta] = useState({ total: 0, limit: 50, offset: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDisputes = async (offset = 0, limit = 50) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.get<AdminListResponse<AdminDispute>>(
+        `/admin/disputes?limit=${limit}&offset=${offset}`
+      );
+      setData(response.data.data);
+      setMeta(response.data.meta);
+    } catch (err) {
+      console.error('Failed to fetch disputes:', err);
+      setError('Failed to load disputes. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDisputes();
+  }, []);
+
+  const handlePageChange = (offset: number) => {
+    fetchDisputes(offset, meta.limit);
+  };
+
+  const handleLimitChange = (limit: number) => {
+    fetchDisputes(0, limit);
+  };
+
+  const columns = [
+    {
+      key: 'id',
+      label: 'ID',
+      sortable: true,
+    },
+    {
+      key: 'sessionId',
+      label: 'Session ID',
+      sortable: true,
+    },
+    {
+      key: 'type',
+      label: 'Type',
+      sortable: true,
+    },
+    {
+      key: 'mentorName',
+      label: 'Mentor',
+      sortable: true,
+    },
+    {
+      key: 'learnerName',
+      label: 'Learner',
+      sortable: true,
+    },
+    {
+      key: 'amount',
+      label: 'Amount',
+      sortable: true,
+      render: (value: number, item: AdminDispute) => `${value} ${item.asset}`,
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      sortable: true,
+      render: (value: string) => {
+        const colors = {
+          open: 'bg-red-100 text-red-800',
+          investigating: 'bg-yellow-100 text-yellow-800',
+          resolved: 'bg-green-100 text-green-800',
+          closed: 'bg-gray-100 text-gray-800',
+        };
+        return (
+          <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${colors[value as keyof typeof colors] || 'bg-gray-100 text-gray-800'}`}>
+            {value}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'createdAt',
+      label: 'Created',
+      sortable: true,
+      render: (value: string) => new Date(value).toLocaleDateString(),
+    },
+    {
+      key: 'resolvedAt',
+      label: 'Resolved',
+      sortable: true,
+      render: (value?: string) => value ? new Date(value).toLocaleDateString() : '-',
+    },
+  ];
+
+  return (
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Disputes</h1>
+        <p className="text-gray-500">Manage session disputes</p>
+      </div>
+
+      <AdminTable
+        data={data}
+        columns={columns}
+        meta={meta}
+        loading={loading}
+        error={error}
+        onPageChange={handlePageChange}
+        onLimitChange={handleLimitChange}
+        title="Disputes"
+      />
+    </div>
+  );
+};
+
+export default AdminDisputes;

--- a/src/components/admin/AdminLogs.tsx
+++ b/src/components/admin/AdminLogs.tsx
@@ -1,0 +1,168 @@
+import React, { useState, useEffect } from 'react';
+import { AdminTable } from './AdminTable';
+import { AdminLog, AdminListResponse } from '../../types/admin.types';
+import apiClient from '../../services/api.client';
+
+const LEVEL_OPTIONS = ['All', 'info', 'warn', 'error'] as const;
+type LevelFilter = typeof LEVEL_OPTIONS[number];
+
+const AdminLogs: React.FC = () => {
+  const [data, setData] = useState<AdminLog[]>([]);
+  const [meta, setMeta] = useState({ total: 0, limit: 50, offset: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [levelFilter, setLevelFilter] = useState<LevelFilter>('All');
+  const [actionFilter, setActionFilter] = useState('');
+  const [userIdFilter, setUserIdFilter] = useState('');
+
+  const fetchLogs = async (offset = 0, limit = 50) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({
+        limit: limit.toString(),
+        offset: offset.toString(),
+      });
+
+      if (levelFilter !== 'All') {
+        params.append('level', levelFilter);
+      }
+      if (actionFilter) {
+        params.append('action', actionFilter);
+      }
+      if (userIdFilter) {
+        params.append('userId', userIdFilter);
+      }
+
+      const response = await apiClient.get<AdminListResponse<AdminLog>>(`/admin/logs?${params}`);
+      setData(response.data.data);
+      setMeta(response.data.meta);
+    } catch (err) {
+      console.error('Failed to fetch logs:', err);
+      setError('Failed to load logs. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchLogs(meta.offset, meta.limit);
+  }, [levelFilter, actionFilter, userIdFilter]);
+
+  const handlePageChange = (offset: number) => {
+    fetchLogs(offset, meta.limit);
+  };
+
+  const handleLimitChange = (limit: number) => {
+    fetchLogs(0, limit);
+  };
+
+  const columns = [
+    {
+      key: 'timestamp',
+      label: 'Timestamp',
+      sortable: true,
+      render: (value: string) => new Date(value).toLocaleString(),
+    },
+    {
+      key: 'level',
+      label: 'Level',
+      sortable: true,
+      render: (value: string) => {
+        const colors = {
+          info: 'bg-blue-100 text-blue-800',
+          warn: 'bg-yellow-100 text-yellow-800',
+          error: 'bg-red-100 text-red-800',
+        };
+        return (
+          <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${colors[value as keyof typeof colors] || 'bg-gray-100 text-gray-800'}`}>
+            {value}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'action',
+      label: 'Action',
+      sortable: true,
+    },
+    {
+      key: 'userName',
+      label: 'User',
+      sortable: true,
+      render: (value?: string, item: AdminLog) => value || (item.userId ? `ID: ${item.userId}` : '-'),
+    },
+    {
+      key: 'ipAddress',
+      label: 'IP Address',
+      sortable: true,
+    },
+    {
+      key: 'details',
+      label: 'Details',
+      sortable: false,
+    },
+  ];
+
+  const filters = (
+    <div className="flex items-center gap-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Level:</label>
+        <select
+          value={levelFilter}
+          onChange={(e) => setLevelFilter(e.target.value as LevelFilter)}
+          className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+        >
+          {LEVEL_OPTIONS.map((level) => (
+            <option key={level} value={level}>
+              {level}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Action:</label>
+        <input
+          type="text"
+          value={actionFilter}
+          onChange={(e) => setActionFilter(e.target.value)}
+          placeholder="Filter by action"
+          className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">User ID:</label>
+        <input
+          type="text"
+          value={userIdFilter}
+          onChange={(e) => setUserIdFilter(e.target.value)}
+          placeholder="Filter by user ID"
+          className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Logs</h1>
+        <p className="text-gray-500">View system logs and activities</p>
+      </div>
+
+      <AdminTable
+        data={data}
+        columns={columns}
+        meta={meta}
+        loading={loading}
+        error={error}
+        onPageChange={handlePageChange}
+        onLimitChange={handleLimitChange}
+        title="System Logs"
+        filters={filters}
+      />
+    </div>
+  );
+};
+
+export default AdminLogs;

--- a/src/components/admin/AdminPayments.tsx
+++ b/src/components/admin/AdminPayments.tsx
@@ -1,0 +1,120 @@
+import React, { useState, useEffect } from 'react';
+import { AdminTable } from './AdminTable';
+import { AdminPayment, AdminListResponse } from '../../types/admin.types';
+import apiClient from '../../services/api.client';
+
+const AdminPayments: React.FC = () => {
+  const [data, setData] = useState<AdminPayment[]>([]);
+  const [meta, setMeta] = useState({ total: 0, limit: 50, offset: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPayments = async (offset = 0, limit = 50) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.get<AdminListResponse<AdminPayment>>(
+        `/admin/payments?limit=${limit}&offset=${offset}`
+      );
+      setData(response.data.data);
+      setMeta(response.data.meta);
+    } catch (err) {
+      console.error('Failed to fetch payments:', err);
+      setError('Failed to load payments. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPayments();
+  }, []);
+
+  const handlePageChange = (offset: number) => {
+    fetchPayments(offset, meta.limit);
+  };
+
+  const handleLimitChange = (limit: number) => {
+    fetchPayments(0, limit);
+  };
+
+  const columns = [
+    {
+      key: 'id',
+      label: 'ID',
+      sortable: true,
+    },
+    {
+      key: 'sessionId',
+      label: 'Session ID',
+      sortable: true,
+    },
+    {
+      key: 'mentorName',
+      label: 'Mentor',
+      sortable: true,
+    },
+    {
+      key: 'learnerName',
+      label: 'Learner',
+      sortable: true,
+    },
+    {
+      key: 'amount',
+      label: 'Amount',
+      sortable: true,
+      render: (value: number, item: AdminPayment) => `${value} ${item.asset}`,
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      sortable: true,
+      render: (value: string) => {
+        const colors = {
+          completed: 'bg-green-100 text-green-800',
+          pending: 'bg-yellow-100 text-yellow-800',
+          failed: 'bg-red-100 text-red-800',
+        };
+        return (
+          <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${colors[value as keyof typeof colors] || 'bg-gray-100 text-gray-800'}`}>
+            {value}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'stellarTxHash',
+      label: 'Tx Hash',
+      sortable: false,
+      render: (value?: string) => value ? `${value.slice(0, 8)}...` : '-',
+    },
+    {
+      key: 'createdAt',
+      label: 'Created',
+      sortable: true,
+      render: (value: string) => new Date(value).toLocaleDateString(),
+    },
+  ];
+
+  return (
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Payments</h1>
+        <p className="text-gray-500">View all payment transactions</p>
+      </div>
+
+      <AdminTable
+        data={data}
+        columns={columns}
+        meta={meta}
+        loading={loading}
+        error={error}
+        onPageChange={handlePageChange}
+        onLimitChange={handleLimitChange}
+        title="Payments"
+      />
+    </div>
+  );
+};
+
+export default AdminPayments;

--- a/src/components/admin/AdminSessions.tsx
+++ b/src/components/admin/AdminSessions.tsx
@@ -1,0 +1,122 @@
+import React, { useState, useEffect } from 'react';
+import { AdminTable } from './AdminTable';
+import { AdminSession, AdminListResponse } from '../../types/admin.types';
+import apiClient from '../../services/api.client';
+
+const AdminSessions: React.FC = () => {
+  const [data, setData] = useState<AdminSession[]>([]);
+  const [meta, setMeta] = useState({ total: 0, limit: 50, offset: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSessions = async (offset = 0, limit = 50) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.get<AdminListResponse<AdminSession>>(
+        `/admin/sessions?limit=${limit}&offset=${offset}`
+      );
+      setData(response.data.data);
+      setMeta(response.data.meta);
+    } catch (err) {
+      console.error('Failed to fetch sessions:', err);
+      setError('Failed to load sessions. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSessions();
+  }, []);
+
+  const handlePageChange = (offset: number) => {
+    fetchSessions(offset, meta.limit);
+  };
+
+  const handleLimitChange = (limit: number) => {
+    fetchSessions(0, limit);
+  };
+
+  const columns = [
+    {
+      key: 'id',
+      label: 'ID',
+      sortable: true,
+    },
+    {
+      key: 'mentorName',
+      label: 'Mentor',
+      sortable: true,
+    },
+    {
+      key: 'learnerName',
+      label: 'Learner',
+      sortable: true,
+    },
+    {
+      key: 'scheduledAt',
+      label: 'Scheduled',
+      sortable: true,
+      render: (value: string) => new Date(value).toLocaleString(),
+    },
+    {
+      key: 'duration',
+      label: 'Duration',
+      sortable: true,
+      render: (value: number) => `${value} min`,
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      sortable: true,
+      render: (value: string) => {
+        const colors = {
+          pending: 'bg-yellow-100 text-yellow-800',
+          confirmed: 'bg-blue-100 text-blue-800',
+          completed: 'bg-green-100 text-green-800',
+          cancelled: 'bg-red-100 text-red-800',
+          rescheduled: 'bg-purple-100 text-purple-800',
+        };
+        return (
+          <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${colors[value as keyof typeof colors] || 'bg-gray-100 text-gray-800'}`}>
+            {value}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'price',
+      label: 'Price',
+      sortable: true,
+      render: (value: number, item: AdminSession) => `${value} ${item.asset}`,
+    },
+    {
+      key: 'topic',
+      label: 'Topic',
+      sortable: true,
+    },
+  ];
+
+  return (
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Sessions</h1>
+        <p className="text-gray-500">View all mentoring sessions</p>
+      </div>
+
+      <AdminTable
+        data={data}
+        columns={columns}
+        meta={meta}
+        loading={loading}
+        error={error}
+        onPageChange={handlePageChange}
+        onLimitChange={handleLimitChange}
+        title="Sessions"
+      />
+    </div>
+  );
+};
+
+export default AdminSessions;

--- a/src/components/admin/AdminTable.tsx
+++ b/src/components/admin/AdminTable.tsx
@@ -1,0 +1,233 @@
+import React, { useState, useMemo } from 'react';
+import { ChevronLeft, ChevronRight, Download } from 'lucide-react';
+
+interface AdminTableColumn<T> {
+  key: keyof T | string;
+  label: string;
+  sortable?: boolean;
+  render?: (value: any, item: T) => React.ReactNode;
+}
+
+interface AdminTableProps<T> {
+  data: T[];
+  columns: AdminTableColumn<T>[];
+  meta: {
+    total: number;
+    limit: number;
+    offset: number;
+  };
+  loading?: boolean;
+  error?: string | null;
+  onPageChange: (offset: number) => void;
+  onLimitChange: (limit: number) => void;
+  title?: string;
+  filters?: React.ReactNode;
+  exportUrl?: string;
+  onExport?: () => void;
+  exportLoading?: boolean;
+}
+
+const PER_PAGE_OPTIONS = [25, 50, 100];
+
+export function AdminTable<T extends Record<string, any>>({
+  data,
+  columns,
+  meta,
+  loading = false,
+  error,
+  onPageChange,
+  onLimitChange,
+  title,
+  filters,
+  exportUrl,
+  onExport,
+  exportLoading = false,
+}: AdminTableProps<T>) {
+  const [sortField, setSortField] = useState<string | null>(null);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  const currentPage = Math.floor(meta.offset / meta.limit) + 1;
+  const totalPages = Math.ceil(meta.total / meta.limit);
+  const startResult = meta.offset + 1;
+  const endResult = Math.min(meta.offset + data.length, meta.total);
+
+  const sortedData = useMemo(() => {
+    if (!sortField || loading) return data;
+
+    return [...data].sort((a, b) => {
+      const aVal = a[sortField];
+      const bVal = b[sortField];
+
+      if (aVal < bVal) return sortDirection === 'asc' ? -1 : 1;
+      if (aVal > bVal) return sortDirection === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }, [data, sortField, sortDirection, loading]);
+
+  const handleSort = (field: string) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDirection('asc');
+    }
+  };
+
+  const handlePageChange = (page: number) => {
+    const newOffset = (page - 1) * meta.limit;
+    onPageChange(newOffset);
+  };
+
+  const handlePrevPage = () => {
+    if (currentPage > 1) {
+      handlePageChange(currentPage - 1);
+    }
+  };
+
+  const handleNextPage = () => {
+    if (currentPage < totalPages) {
+      handlePageChange(currentPage + 1);
+    }
+  };
+
+  const renderCell = (item: T, column: AdminTableColumn<T>) => {
+    const value = item[column.key as keyof T];
+    return column.render ? column.render(value, item) : String(value || '');
+  };
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+        <p className="text-red-600">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
+      {/* Header */}
+      <div className="px-6 py-4 border-b border-gray-200">
+        <div className="flex justify-between items-center">
+          {title && <h2 className="text-lg font-semibold text-gray-900">{title}</h2>}
+          <div className="flex items-center gap-4">
+            {exportUrl && onExport && (
+              <button
+                onClick={onExport}
+                disabled={exportLoading}
+                className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Download size={16} />
+                {exportLoading ? 'Exporting...' : 'Export CSV'}
+              </button>
+            )}
+          </div>
+        </div>
+        {filters && <div className="mt-4">{filters}</div>}
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead className="bg-gray-50">
+            <tr>
+              {columns.map((column) => (
+                <th
+                  key={String(column.key)}
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  {column.sortable ? (
+                    <button
+                      onClick={() => handleSort(String(column.key))}
+                      className="flex items-center hover:text-gray-700"
+                    >
+                      {column.label}
+                      {sortField === column.key && (
+                        <span className="ml-1">
+                          {sortDirection === 'asc' ? '↑' : '↓'}
+                        </span>
+                      )}
+                    </button>
+                  ) : (
+                    column.label
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {loading ? (
+              Array.from({ length: meta.limit }).map((_, i) => (
+                <tr key={i}>
+                  {columns.map((_, j) => (
+                    <td key={j} className="px-6 py-4 whitespace-nowrap">
+                      <div className="animate-pulse h-4 bg-gray-200 rounded"></div>
+                    </td>
+                  ))}
+                </tr>
+              ))
+            ) : sortedData.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} className="px-6 py-8 text-center text-gray-500">
+                  No results found
+                </td>
+              </tr>
+            ) : (
+              sortedData.map((item, index) => (
+                <tr key={index} className="hover:bg-gray-50">
+                  {columns.map((column) => (
+                    <td key={String(column.key)} className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {renderCell(item, column)}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="px-6 py-4 border-t border-gray-200 bg-gray-50">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <span className="text-sm text-gray-700">
+              Showing {startResult}–{endResult} of {meta.total} results
+            </span>
+            <select
+              value={meta.limit}
+              onChange={(e) => onLimitChange(Number(e.target.value))}
+              className="px-2 py-1 text-sm border border-gray-300 rounded"
+            >
+              {PER_PAGE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option} per page
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handlePrevPage}
+              disabled={currentPage === 1}
+              className="px-3 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft size={16} />
+              Previous
+            </button>
+            <span className="px-3 py-2 text-sm text-gray-700">
+              Page {currentPage} of {totalPages}
+            </span>
+            <button
+              onClick={handleNextPage}
+              disabled={currentPage === totalPages}
+              className="px-3 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Next
+              <ChevronRight size={16} />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AdminTransactions.tsx
+++ b/src/components/admin/AdminTransactions.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import { AdminTable } from './AdminTable';
+import { AdminTransaction, AdminListResponse } from '../../types/admin.types';
+import apiClient from '../../services/api.client';
+
+const AdminTransactions: React.FC = () => {
+  const [data, setData] = useState<AdminTransaction[]>([]);
+  const [meta, setMeta] = useState({ total: 0, limit: 50, offset: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTransactions = async (offset = 0, limit = 50) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.get<AdminListResponse<AdminTransaction>>(
+        `/admin/transactions?limit=${limit}&offset=${offset}`
+      );
+      setData(response.data.data);
+      setMeta(response.data.meta);
+    } catch (err) {
+      console.error('Failed to fetch transactions:', err);
+      setError('Failed to load transactions. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTransactions();
+  }, []);
+
+  const handlePageChange = (offset: number) => {
+    fetchTransactions(offset, meta.limit);
+  };
+
+  const handleLimitChange = (limit: number) => {
+    fetchTransactions(0, limit);
+  };
+
+  const columns = [
+    {
+      key: 'id',
+      label: 'ID',
+      sortable: true,
+    },
+    {
+      key: 'type',
+      label: 'Type',
+      sortable: true,
+      render: (value: string) => (
+        <span className="capitalize">{value}</span>
+      ),
+    },
+    {
+      key: 'amount',
+      label: 'Amount',
+      sortable: true,
+      render: (value: number, item: AdminTransaction) => `${value} ${item.asset}`,
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      sortable: true,
+      render: (value: string) => {
+        const colors = {
+          completed: 'bg-green-100 text-green-800',
+          pending: 'bg-yellow-100 text-yellow-800',
+          failed: 'bg-red-100 text-red-800',
+          refunded: 'bg-blue-100 text-blue-800',
+        };
+        return (
+          <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${colors[value as keyof typeof colors] || 'bg-gray-100 text-gray-800'}`}>
+            {value}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'userName',
+      label: 'User',
+      sortable: true,
+    },
+    {
+      key: 'createdAt',
+      label: 'Created',
+      sortable: true,
+      render: (value: string) => new Date(value).toLocaleDateString(),
+    },
+  ];
+
+  return (
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Transactions</h1>
+        <p className="text-gray-500">View all platform transactions</p>
+      </div>
+
+      <AdminTable
+        data={data}
+        columns={columns}
+        meta={meta}
+        loading={loading}
+        error={error}
+        onPageChange={handlePageChange}
+        onLimitChange={handleLimitChange}
+        title="Transactions"
+      />
+    </div>
+  );
+};
+
+export default AdminTransactions;

--- a/src/components/admin/AdminUsers.tsx
+++ b/src/components/admin/AdminUsers.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from 'react';
+import { AdminTable } from './AdminTable';
+import { AdminUser, AdminListResponse } from '../../types/admin.types';
+import apiClient from '../../services/api.client';
+
+const ROLE_OPTIONS = ['All', 'Mentee', 'Mentor', 'Admin'] as const;
+type RoleFilter = typeof ROLE_OPTIONS[number];
+
+const AdminUsers: React.FC = () => {
+  const [data, setData] = useState<AdminUser[]>([]);
+  const [meta, setMeta] = useState({ total: 0, limit: 50, offset: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>('All');
+
+  const fetchUsers = async (offset = 0, limit = 50) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({
+        limit: limit.toString(),
+        offset: offset.toString(),
+      });
+
+      if (roleFilter !== 'All') {
+        params.append('role', roleFilter.toLowerCase());
+      }
+
+      const response = await apiClient.get<AdminListResponse<AdminUser>>(`/admin/users?${params}`);
+      setData(response.data.data);
+      setMeta(response.data.meta);
+    } catch (err) {
+      console.error('Failed to fetch users:', err);
+      setError('Failed to load users. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUsers(meta.offset, meta.limit);
+  }, [roleFilter]);
+
+  const handlePageChange = (offset: number) => {
+    fetchUsers(offset, meta.limit);
+  };
+
+  const handleLimitChange = (limit: number) => {
+    fetchUsers(0, limit);
+  };
+
+  const columns = [
+    {
+      key: 'id',
+      label: 'ID',
+      sortable: true,
+    },
+    {
+      key: 'name',
+      label: 'Name',
+      sortable: true,
+    },
+    {
+      key: 'email',
+      label: 'Email',
+      sortable: true,
+    },
+    {
+      key: 'role',
+      label: 'Role',
+      sortable: true,
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      sortable: true,
+      render: (value: string) => {
+        const colors = {
+          active: 'bg-green-100 text-green-800',
+          inactive: 'bg-gray-100 text-gray-800',
+          suspended: 'bg-red-100 text-red-800',
+        };
+        return (
+          <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${colors[value as keyof typeof colors] || 'bg-gray-100 text-gray-800'}`}>
+            {value}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'createdAt',
+      label: 'Created',
+      sortable: true,
+      render: (value: string) => new Date(value).toLocaleDateString(),
+    },
+    {
+      key: 'lastActive',
+      label: 'Last Active',
+      sortable: true,
+      render: (value?: string) => value ? new Date(value).toLocaleDateString() : 'Never',
+    },
+  ];
+
+  const filters = (
+    <div className="flex items-center gap-4">
+      <label className="text-sm font-medium text-gray-700">Role:</label>
+      <select
+        value={roleFilter}
+        onChange={(e) => setRoleFilter(e.target.value as RoleFilter)}
+        className="px-3 py-2 border border-gray-300 rounded-md text-sm"
+      >
+        {ROLE_OPTIONS.map((role) => (
+          <option key={role} value={role}>
+            {role}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+
+  return (
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+        <p className="text-gray-500">Manage platform users</p>
+      </div>
+
+      <AdminTable
+        data={data}
+        columns={columns}
+        meta={meta}
+        loading={loading}
+        error={error}
+        onPageChange={handlePageChange}
+        onLimitChange={handleLimitChange}
+        title="Users"
+        filters={filters}
+      />
+    </div>
+  );
+};
+
+export default AdminUsers;

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -1,0 +1,8 @@
+export { default as AdminAnalytics } from './AdminAnalytics';
+export { default as AdminUsers } from './AdminUsers';
+export { default as AdminTransactions } from './AdminTransactions';
+export { default as AdminSessions } from './AdminSessions';
+export { default as AdminPayments } from './AdminPayments';
+export { default as AdminDisputes } from './AdminDisputes';
+export { default as AdminLogs } from './AdminLogs';
+export { AdminTable } from './AdminTable';

--- a/src/types/admin.types.ts
+++ b/src/types/admin.types.ts
@@ -1,0 +1,82 @@
+// Admin types for list endpoints
+
+export interface AdminListMeta {
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface AdminUser {
+  id: string;
+  email: string;
+  name: string;
+  role: 'Mentee' | 'Mentor' | 'Admin';
+  createdAt: string;
+  lastActive?: string;
+  status: 'active' | 'inactive' | 'suspended';
+}
+
+export interface AdminTransaction {
+  id: string;
+  type: 'payment' | 'refund' | 'payout';
+  amount: number;
+  asset: string;
+  status: string;
+  createdAt: string;
+  userId: string;
+  userName: string;
+  sessionId?: string;
+}
+
+export interface AdminSession {
+  id: string;
+  mentorName: string;
+  learnerName: string;
+  scheduledAt: string;
+  duration: number;
+  status: string;
+  price: number;
+  asset: string;
+  topic?: string;
+}
+
+export interface AdminPayment {
+  id: string;
+  sessionId: string;
+  amount: number;
+  asset: string;
+  status: string;
+  stellarTxHash?: string;
+  createdAt: string;
+  mentorName: string;
+  learnerName: string;
+}
+
+export interface AdminDispute {
+  id: string;
+  sessionId: string;
+  type: string;
+  status: string;
+  createdAt: string;
+  resolvedAt?: string;
+  mentorName: string;
+  learnerName: string;
+  amount: number;
+  asset: string;
+}
+
+export interface AdminLog {
+  id: string;
+  timestamp: string;
+  level: 'info' | 'warn' | 'error';
+  action: string;
+  userId?: string;
+  userName?: string;
+  ipAddress?: string;
+  details?: string;
+}
+
+export interface AdminListResponse<T> {
+  data: T[];
+  meta: AdminListMeta;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,10 @@
 import type { Goal, GoalStatus, GoalCategory, Milestone, GoalSummary, GoalStats, CreateGoalPayload, UpdateGoalPayload, UpdateProgressPayload, LinkSessionPayload, GoalTemplate } from './goals.types.js';
 import type { PaymentStatus } from './payment.types';
+import type { AdminUser, AdminTransaction, AdminSession, AdminPayment, AdminDispute, AdminLog, AdminListResponse } from './admin.types';
 
 export type { Goal, GoalStatus, GoalCategory, Milestone, GoalSummary, GoalStats, CreateGoalPayload, UpdateGoalPayload, UpdateProgressPayload, LinkSessionPayload, GoalTemplate };
 export * from './payment.types';
+export type { AdminUser, AdminTransaction, AdminSession, AdminPayment, AdminDispute, AdminLog, AdminListResponse };
 
 // Global shared types
 

--- a/src/utils/analyticsExport.utils.ts
+++ b/src/utils/analyticsExport.utils.ts
@@ -1,0 +1,48 @@
+// CSV export utilities for admin analytics
+
+export const exportAnalyticsCSV = async (
+  endpoint: string,
+  period: string,
+  filename: string
+): Promise<void> => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL || ''}${endpoint}?format=csv&period=${period}`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${localStorage.getItem('authToken')}`,
+      },
+    });
+
+    if (response.status === 503) {
+      throw new Error('Analytics data is being prepared. Please try again in a few minutes.');
+    }
+
+    if (!response.ok) {
+      throw new Error('Failed to export CSV');
+    }
+
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+
+    // Get filename from Content-Disposition header
+    const contentDisposition = response.headers.get('content-disposition');
+    let downloadFilename = filename;
+    if (contentDisposition) {
+      const filenameMatch = contentDisposition.match(/filename="(.+)"/);
+      if (filenameMatch) {
+        downloadFilename = filenameMatch[1];
+      }
+    }
+
+    // Create download link
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = downloadFilename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
feat(admin): implement offset pagination and analytics CSV export (#322, #323)

- Implement offset-based pagination for all admin list endpoints
  - Support limit/offset query params across /admin/* endpoints
  - Add page-number navigation (calculated from offset/limit)
  - Implement Previous/Next controls (±limit offset updates)
  - Display "Showing X–Y of Z results" using meta { total, limit, offset }
  - Add "per page" selector (25, 50, 100) with default 50
  - Add filters:
    - Users: role (All, Mentee, Mentor, Admin)
    - Logs: action, userId, level
  - Enable client-side sorting without re-fetching data

- Implement analytics CSV export functionality
  - Add "Export CSV" button with ?format=csv&period= query params
  - Fetch CSV as blob with Authorization header
  - Trigger file download using URL.createObjectURL
  - Extract and apply filename from Content-Disposition header
  - Show loading state during export and reset after download starts
  - Handle 503 errors with user-friendly retry message

- Ensure UI/UX consistency across admin panel components

closes #322 
closes #323 