### PR TITLE
feat(account): implement account deletion flow with grace period and …

### DIFF
--- a/src/components/settings/DangerZoneSettings.tsx
+++ b/src/components/settings/DangerZoneSettings.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Trash2, AlertTriangle, Loader2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import FocusTrap from '../a11y/FocusTrap';
 import AccountService from '../../services/account.service';
 import { useAuth } from '../../hooks/useAuth';
@@ -11,19 +12,26 @@ const DangerZoneSettings: React.FC = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
-  
+
   const accountService = new AccountService();
   const { logout } = useAuth();
+  const navigate = useNavigate();
 
   const handleDelete = async () => {
+    if (deleteConfirm !== 'DELETE') return;
     setIsDeleting(true);
     try {
-      await accountService.deleteAccount();
-      toast.success('Account deleted successfully');
+      const result = await accountService.requestDeletion();
+      // Tokens are revoked server-side — log out immediately
+      await logout();
       setShowDeleteModal(false);
-      logout();
+      // Redirect to the scheduled-for-deletion page with the date
+      navigate('/account-scheduled-for-deletion', {
+        state: { deletion_scheduled_for: result.deletion_scheduled_for },
+        replace: true,
+      });
     } catch (err) {
-      toast.error('Failed to delete account');
+      toast.error('Failed to schedule account deletion');
       console.error(err);
       setIsDeleting(false);
     }
@@ -39,7 +47,7 @@ const DangerZoneSettings: React.FC = () => {
           <div>
             <h3 className="text-lg font-bold text-red-900 mb-1">Delete Account</h3>
             <p className="text-sm text-red-700/80 mb-4 max-w-xl">
-              Permanently delete your account and all associated data. This action is irreversible. All your sessions, goals, and history will be permanently erased.
+              Schedule your account for permanent deletion. You will have 30 days to cancel before all data is erased.
             </p>
             <button
               onClick={() => setShowDeleteModal(true)}
@@ -61,11 +69,11 @@ const DangerZoneSettings: React.FC = () => {
                 </div>
                 <h3 className="text-xl font-bold text-gray-900">Delete Account?</h3>
               </div>
-              
+
               <p className="text-sm text-gray-600 mb-6 leading-relaxed">
-                This action <strong className="text-gray-900">cannot be undone</strong>. This will permanently delete your account, settings, and all your history.
+                Your account will be <strong className="text-gray-900">permanently deleted in 30 days</strong>. You will be logged out immediately. You can cancel the deletion by logging back in during the grace period.
               </p>
-              
+
               <div className="mb-6">
                 <label className="block text-sm font-semibold text-gray-900 mb-2">
                   To verify, type <span className="font-mono text-red-600 select-all">DELETE</span> below:
@@ -80,9 +88,9 @@ const DangerZoneSettings: React.FC = () => {
                   autoComplete="off"
                 />
               </div>
-              
+
               <div className="flex gap-3">
-                <button 
+                <button
                   onClick={() => { setShowDeleteModal(false); setDeleteConfirm(''); }}
                   disabled={isDeleting}
                   className="flex-1 px-4 py-2.5 border border-gray-200 text-gray-700 text-sm font-bold rounded-xl hover:bg-gray-50 transition-colors disabled:opacity-50"
@@ -95,7 +103,7 @@ const DangerZoneSettings: React.FC = () => {
                   className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-red-600 text-white text-sm font-bold rounded-xl hover:bg-red-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shadow-sm shadow-red-600/20"
                 >
                   {isDeleting && <Loader2 className="w-4 h-4 animate-spin" />}
-                  {isDeleting ? 'Deleting...' : 'Delete Account'}
+                  {isDeleting ? 'Scheduling...' : 'Delete Account'}
                 </button>
               </div>
             </div>

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useMobile } from '../hooks/useMobile';
 import { useNavLayout } from '../hooks/useNavLayout';
@@ -94,6 +95,24 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
           />
         )}
         {showDeniedTooltip && <DeniedTooltip onDismiss={dismissDeniedTooltip} />}
+
+        {/* Account deletion pending amber banner */}
+        {(user as { deletion_scheduled_for?: string } | null)?.deletion_scheduled_for && (
+          <div className="flex items-center justify-between gap-3 px-4 py-2.5 bg-amber-50 border-b border-amber-200 text-amber-900 text-sm">
+            <span>
+              ⚠️ Your account is scheduled for deletion on{' '}
+              <strong>
+                {new Date((user as { deletion_scheduled_for: string }).deletion_scheduled_for).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+              </strong>.
+            </span>
+            <Link
+              to="/account-scheduled-for-deletion"
+              className="font-semibold underline hover:text-amber-700 whitespace-nowrap"
+            >
+              Cancel
+            </Link>
+          </div>
+        )}
 
         {/* Main content — overscroll-behavior: contain prevents pull-to-refresh bleed;
             -webkit-overflow-scrolling: touch enables momentum scrolling on iOS (Req 8.6).

--- a/src/pages/AccountScheduledForDeletion.tsx
+++ b/src/pages/AccountScheduledForDeletion.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { AlertTriangle, Loader2, Trash2 } from 'lucide-react';
+import AccountService from '../services/account.service';
+import toast from 'react-hot-toast';
+
+const AccountScheduledForDeletion: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [cancelling, setCancelling] = useState(false);
+
+  const deletionDate: string | undefined = (location.state as { deletion_scheduled_for?: string } | null)?.deletion_scheduled_for;
+
+  const formattedDate = deletionDate
+    ? new Date(deletionDate).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : 'in 30 days';
+
+  const handleCancelDeletion = async () => {
+    setCancelling(true);
+    try {
+      const accountService = new AccountService();
+      await accountService.cancelDeletion();
+      toast.success('Account deletion cancelled. Please log in again.');
+      navigate('/');
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 404) {
+        toast.error('No pending deletion request found.');
+      } else {
+        toast.error('Failed to cancel deletion. Please try again.');
+      }
+      console.error(err);
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-3xl shadow-sm border border-gray-100 p-8 max-w-md w-full text-center space-y-6">
+        <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto">
+          <Trash2 className="w-8 h-8 text-red-600" />
+        </div>
+
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold text-gray-900">Account Scheduled for Deletion</h1>
+          <p className="text-gray-600 text-sm leading-relaxed">
+            Your account will be permanently deleted on{' '}
+            <strong className="text-gray-900">{formattedDate}</strong>.
+            All your data, sessions, and history will be erased.
+          </p>
+        </div>
+
+        <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-2xl text-left">
+          <AlertTriangle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+          <p className="text-sm text-amber-800">
+            You can cancel this deletion by clicking the button below. You will be redirected to log in again.
+          </p>
+        </div>
+
+        <button
+          onClick={handleCancelDeletion}
+          disabled={cancelling}
+          className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {cancelling && <Loader2 className="w-4 h-4 animate-spin" />}
+          {cancelling ? 'Cancelling...' : 'Cancel Deletion'}
+        </button>
+
+        <p className="text-xs text-gray-400">
+          If you did not request this, please contact support immediately.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default AccountScheduledForDeletion;

--- a/src/services/account.service.ts
+++ b/src/services/account.service.ts
@@ -79,4 +79,18 @@ export default class AccountService {
       opts
     );
   }
+
+  async requestDeletion(opts?: RequestOptions): Promise<{ deletion_scheduled_for: string }> {
+    return request<{ deletion_scheduled_for: string }>(
+      { method: 'POST', url: 'users/me/request-deletion' },
+      opts
+    );
+  }
+
+  async cancelDeletion(opts?: RequestOptions): Promise<void> {
+    return request<void>(
+      { method: 'POST', url: 'users/me/cancel-deletion' },
+      opts
+    );
+  }
 }


### PR DESCRIPTION
…cancellation

- DangerZoneSettings: requires typing DELETE, calls POST /users/me/request-deletion
- After request: logs out immediately (tokens revoked server-side) and redirects to /account-scheduled-for-deletion with deletion_scheduled_for date
- AccountScheduledForDeletion page: shows deletion date, Cancel Deletion button calls POST /users/me/cancel-deletion, handles 404 gracefully
- DashboardLayout: amber banner for users with deletion_scheduled_for on user object with Cancel link to /account-scheduled-for-deletion
- Added requestDeletion() and cancelDeletion() to AccountService

Closes #315