### PR TITLE
feat: align conversation list UI with server API shape

### DIFF
--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Conversation } from '../../services/messaging.service';
+import UserAvatar from '../ui/UserAvatar';
 
 interface ConversationListProps {
   conversations: Conversation[];
@@ -19,6 +20,20 @@ const formatTimeAgo = (dateString: string): string => {
   return new Date(dateString).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 };
 
+const LastMessagePreview: React.FC<{ body: string | null; hasUnread: boolean }> = ({ body, hasUnread }) => {
+  if (body === null) {
+    return <p className="text-xs truncate italic text-gray-400">No messages yet</p>;
+  }
+  if (body === '[Message deleted]') {
+    return <p className="text-xs truncate italic text-gray-400">[Message deleted]</p>;
+  }
+  return (
+    <p className={`text-xs truncate ${hasUnread ? 'text-gray-700 font-medium' : 'text-gray-500'}`}>
+      {body}
+    </p>
+  );
+};
+
 const ConversationList: React.FC<ConversationListProps> = ({
   conversations,
   activeConversationId,
@@ -29,7 +44,9 @@ const ConversationList: React.FC<ConversationListProps> = ({
       {/* Header */}
       <div className="px-4 py-3 border-b border-gray-100">
         <h2 className="text-base font-bold text-gray-900">Messages</h2>
-        <p className="text-xs text-gray-400 mt-0.5">{conversations.length} conversation{conversations.length !== 1 ? 's' : ''}</p>
+        <p className="text-xs text-gray-400 mt-0.5">
+          {conversations.length} conversation{conversations.length !== 1 ? 's' : ''}
+        </p>
       </div>
 
       {/* List */}
@@ -48,7 +65,7 @@ const ConversationList: React.FC<ConversationListProps> = ({
           <ul className="divide-y divide-gray-50">
             {conversations.map((conv) => {
               const isActive = activeConversationId === conv.id;
-              const lastMsgIsOwn = conv.lastMessage?.senderId === 'learner1';
+              const hasUnread = conv.unread_count > 0;
 
               return (
                 <li key={conv.id}>
@@ -58,51 +75,31 @@ const ConversationList: React.FC<ConversationListProps> = ({
                       isActive ? 'bg-stellar/5 border-l-2 border-stellar' : ''
                     }`}
                   >
-                    {/* Avatar + online dot */}
-                    <div className="relative flex-shrink-0">
-                      {conv.participantAvatar ? (
-                        <img
-                          src={conv.participantAvatar}
-                          alt={conv.participantName}
-                          className="w-11 h-11 rounded-full object-cover"
-                        />
-                      ) : (
-                        <div className="w-11 h-11 rounded-full bg-stellar flex items-center justify-center text-white font-bold text-sm">
-                          {conv.participantName[0]}
-                        </div>
-                      )}
-                      {/* Online indicator */}
-                      {conv.participantOnline && (
-                        <span
-                          className="absolute bottom-0 right-0 w-3 h-3 bg-emerald-500 border-2 border-white rounded-full"
-                          aria-label="Online"
-                        />
-                      )}
-                    </div>
+                    <UserAvatar
+                      avatarUrl={conv.other_user_avatar}
+                      name={conv.other_user_name}
+                      size="md"
+                      className="flex-shrink-0"
+                    />
 
-                    {/* Content */}
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center justify-between gap-1">
-                        <span className={`text-sm truncate ${conv.unreadCount > 0 ? 'font-bold text-gray-900' : 'font-medium text-gray-800'}`}>
-                          {conv.participantName}
+                        <span className={`text-sm truncate ${hasUnread ? 'font-bold text-gray-900' : 'font-medium text-gray-800'}`}>
+                          {conv.other_user_name}
                         </span>
-                        <span className="text-xs text-gray-400 flex-shrink-0">
-                          {formatTimeAgo(conv.updatedAt)}
-                        </span>
+                        {conv.last_message_at && (
+                          <span className="text-xs text-gray-400 flex-shrink-0">
+                            {formatTimeAgo(conv.last_message_at)}
+                          </span>
+                        )}
                       </div>
 
-                      {/* Last message preview */}
                       <div className="flex items-center justify-between gap-1 mt-0.5">
-                        <p className={`text-xs truncate ${conv.unreadCount > 0 ? 'text-gray-700 font-medium' : 'text-gray-500'}`}>
-                          {conv.lastMessage
-                            ? `${lastMsgIsOwn ? 'You: ' : ''}${conv.lastMessage.content}`
-                            : 'No messages yet'}
-                        </p>
+                        <LastMessagePreview body={conv.last_message_body} hasUnread={hasUnread} />
 
-                        {/* Unread badge */}
-                        {conv.unreadCount > 0 && (
+                        {hasUnread && (
                           <span className="flex-shrink-0 min-w-[18px] h-[18px] bg-stellar text-white text-[10px] font-bold rounded-full flex items-center justify-center px-1">
-                            {conv.unreadCount > 99 ? '99+' : conv.unreadCount}
+                            {conv.unread_count > 99 ? '99+' : conv.unread_count}
                           </span>
                         )}
                       </div>

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,5 +1,6 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Message, Conversation } from '../services/messaging.service';
+import MessagingService from '../services/messaging.service';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -10,191 +11,43 @@ export interface EnhancedMessage extends Message {
   optimistic?: boolean;
 }
 
-// ─── Seed data ────────────────────────────────────────────────────────────────
-
-const INITIAL_CONVERSATIONS: Conversation[] = [
-  {
-    id: 'conv1',
-    participantId: 'mentor1',
-    participantName: 'Aisha Bello',
-    participantAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Aisha',
-    participantOnline: true,
-    unreadCount: 2,
-    updatedAt: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
-    lastMessage: {
-      id: 'msg1',
-      conversationId: 'conv1',
-      senderId: 'mentor1',
-      senderName: 'Aisha Bello',
-      content: 'Looking forward to our session tomorrow!',
-      timestamp: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
-      read: false,
-    },
-  },
-  {
-    id: 'conv2',
-    participantId: 'mentor2',
-    participantName: 'Diego Alvarez',
-    participantAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Diego',
-    participantOnline: false,
-    unreadCount: 0,
-    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
-    lastMessage: {
-      id: 'msg2',
-      conversationId: 'conv2',
-      senderId: 'learner1',
-      senderName: 'You',
-      content: 'Thanks for the feedback on my code!',
-      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
-      read: true,
-    },
-  },
-  {
-    id: 'conv3',
-    participantId: 'mentor3',
-    participantName: 'Nora Chen',
-    participantAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Nora',
-    participantOnline: true,
-    unreadCount: 1,
-    updatedAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-    lastMessage: {
-      id: 'msg3',
-      conversationId: 'conv3',
-      senderId: 'mentor3',
-      senderName: 'Nora Chen',
-      content: 'I have some resources to share with you.',
-      timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-      read: false,
-    },
-  },
-];
-
-// Generate older messages for pagination demo
-const makeOlderMessages = (convId: string, count: number, baseOffset: number): EnhancedMessage[] =>
-  Array.from({ length: count }, (_, i) => ({
-    id: `${convId}-old-${baseOffset + i}`,
-    conversationId: convId,
-    senderId: i % 2 === 0 ? 'learner1' : 'mentor1',
-    senderName: i % 2 === 0 ? 'You' : 'Aisha Bello',
-    senderAvatar: i % 2 !== 0 ? 'https://api.dicebear.com/7.x/avataaars/svg?seed=Aisha' : undefined,
-    content: `Older message ${baseOffset + i + 1} in conversation`,
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * (24 + baseOffset + i)).toISOString(),
-    read: true,
-    status: 'read' as MessageStatus,
-  }));
-
-const INITIAL_MESSAGES: Record<string, EnhancedMessage[]> = {
-  conv1: [
-    {
-      id: 'msg1-1',
-      conversationId: 'conv1',
-      senderId: 'learner1',
-      senderName: 'You',
-      content: 'Hi Aisha! I wanted to confirm our session time.',
-      timestamp: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
-      read: true,
-      status: 'read',
-    },
-    {
-      id: 'msg1-2',
-      conversationId: 'conv1',
-      senderId: 'mentor1',
-      senderName: 'Aisha Bello',
-      senderAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Aisha',
-      content: 'Yes! Tomorrow at 2 PM works perfectly.',
-      timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-      read: true,
-      status: 'read',
-    },
-    {
-      id: 'msg1-3',
-      conversationId: 'conv1',
-      senderId: 'mentor1',
-      senderName: 'Aisha Bello',
-      senderAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Aisha',
-      content: 'Looking forward to our session tomorrow!',
-      timestamp: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
-      read: false,
-      status: 'delivered',
-    },
-  ],
-  conv2: [
-    {
-      id: 'msg2-1',
-      conversationId: 'conv2',
-      senderId: 'mentor2',
-      senderName: 'Diego Alvarez',
-      senderAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Diego',
-      content: 'Great work on the React component!',
-      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(),
-      read: true,
-      status: 'read',
-    },
-    {
-      id: 'msg2-2',
-      conversationId: 'conv2',
-      senderId: 'learner1',
-      senderName: 'You',
-      content: 'Thanks for the feedback on my code!',
-      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
-      read: true,
-      status: 'read',
-    },
-  ],
-  conv3: [
-    {
-      id: 'msg3-1',
-      conversationId: 'conv3',
-      senderId: 'learner1',
-      senderName: 'You',
-      content: 'Hi Nora! Do you have any recommended reading?',
-      timestamp: new Date(Date.now() - 1000 * 60 * 45).toISOString(),
-      read: true,
-      status: 'read',
-    },
-    {
-      id: 'msg3-2',
-      conversationId: 'conv3',
-      senderId: 'mentor3',
-      senderName: 'Nora Chen',
-      senderAvatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Nora',
-      content: 'I have some resources to share with you.',
-      timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-      read: false,
-      status: 'delivered',
-    },
-  ],
-};
-
-// Simulate cursor-based pagination: each conv has 20 older messages available
-const OLDER_MESSAGES_POOL: Record<string, EnhancedMessage[]> = {
-  conv1: makeOlderMessages('conv1', 20, 0),
-  conv2: makeOlderMessages('conv2', 20, 0),
-  conv3: makeOlderMessages('conv3', 20, 0),
-};
+const messagingService = new MessagingService();
 
 // ─── Hook ─────────────────────────────────────────────────────────────────────
 
 export const useMessages = () => {
-  const [conversations, setConversations] = useState<Conversation[]>(INITIAL_CONVERSATIONS);
-  const [messages, setMessages] = useState<Record<string, EnhancedMessage[]>>(INITIAL_MESSAGES);
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [messages, setMessages] = useState<Record<string, EnhancedMessage[]>>({});
   const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<Message[]>([]);
-  const [isLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Typing indicators: set of conversation IDs where the other user is typing
   const [typingConversations, setTypingConversations] = useState<Set<string>>(new Set());
   const typingTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
-  // Cursor pagination: track how many older messages have been loaded per conv
-  const [cursors, setCursors] = useState<Record<string, number>>({});
-  const [hasMore, setHasMore] = useState<Record<string, boolean>>({
-    conv1: true,
-    conv2: true,
-    conv3: true,
-  });
+  // ── Load conversations ────────────────────────────────────────────────────
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    messagingService
+      .getConversations()
+      .then((res) => {
+        if (!cancelled) setConversations(res.data.conversations);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err?.message ?? 'Failed to load conversations');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  // ── Derived ───────────────────────────────────────────────────────────────
 
   const activeConversation = useMemo(
     () => conversations.find((c) => c.id === activeConversationId) ?? null,
@@ -207,7 +60,7 @@ export const useMessages = () => {
   );
 
   const totalUnreadCount = useMemo(
-    () => conversations.reduce((sum, c) => sum + c.unreadCount, 0),
+    () => conversations.reduce((sum, c) => sum + c.unread_count, 0),
     [conversations]
   );
 
@@ -216,16 +69,54 @@ export const useMessages = () => {
     [typingConversations, activeConversationId]
   );
 
-  // ── Socket-style event handlers ──────────────────────────────────────────
+  // ── Mark conversation read (optimistic decrement) ─────────────────────────
 
-  /** Call this when the server emits a "typing" event for a conversation */
+  const markConversationRead = useCallback(async (conversationId: string) => {
+    // Optimistically zero out unread_count immediately
+    setConversations((prev) =>
+      prev.map((c) => (c.id === conversationId ? { ...c, unread_count: 0 } : c))
+    );
+    try {
+      await messagingService.markAsRead(conversationId);
+    } catch {
+      // Best-effort — don't revert; the badge will reconcile on next fetch
+    }
+  }, []);
+
+  // ── Conversation selection ────────────────────────────────────────────────
+
+  const selectConversation = useCallback(
+    async (conversationId: string) => {
+      setActiveConversationId(conversationId || null);
+      setSearchQuery('');
+      setSearchResults([]);
+
+      if (!conversationId) return;
+
+      // Load messages if not already cached
+      if (!messages[conversationId]) {
+        try {
+          const res = await messagingService.getMessages(conversationId);
+          setMessages((prev) => ({ ...prev, [conversationId]: res.data as EnhancedMessage[] }));
+        } catch {
+          // non-fatal
+        }
+      }
+
+      // Mark as read if there are unread messages
+      const conv = conversations.find((c) => c.id === conversationId);
+      if (conv && conv.unread_count > 0) {
+        markConversationRead(conversationId);
+      }
+    },
+    [messages, conversations, markConversationRead]
+  );
+
+  // ── Socket-style event handlers ───────────────────────────────────────────
+
   const handleRemoteTyping = useCallback((conversationId: string) => {
     setTypingConversations((prev) => new Set(prev).add(conversationId));
-
-    // Auto-clear after 3 s of no new typing events
-    if (typingTimers.current[conversationId]) {
-      clearTimeout(typingTimers.current[conversationId]);
-    }
+    if (typingTimers.current[conversationId]) clearTimeout(typingTimers.current[conversationId]);
     typingTimers.current[conversationId] = setTimeout(() => {
       setTypingConversations((prev) => {
         const next = new Set(prev);
@@ -235,33 +126,33 @@ export const useMessages = () => {
     }, 3000);
   }, []);
 
-  /** Call this when the server emits a new incoming message */
-  const handleIncomingMessage = useCallback((message: EnhancedMessage) => {
-    setMessages((prev) => ({
-      ...prev,
-      [message.conversationId]: [...(prev[message.conversationId] ?? []), message],
-    }));
-    setConversations((prev) =>
-      prev.map((c) =>
-        c.id === message.conversationId
-          ? {
-              ...c,
-              lastMessage: message,
-              updatedAt: message.timestamp,
-              unreadCount: c.id === activeConversationId ? 0 : c.unreadCount + 1,
-            }
-          : c
-      )
-    );
-    // Clear typing indicator when message arrives
-    setTypingConversations((prev) => {
-      const next = new Set(prev);
-      next.delete(message.conversationId);
-      return next;
-    });
-  }, [activeConversationId]);
+  const handleIncomingMessage = useCallback(
+    (message: EnhancedMessage) => {
+      setMessages((prev) => ({
+        ...prev,
+        [message.conversationId]: [...(prev[message.conversationId] ?? []), message],
+      }));
+      setConversations((prev) =>
+        prev.map((c) =>
+          c.id === message.conversationId
+            ? {
+                ...c,
+                last_message_body: message.content,
+                last_message_at: message.timestamp,
+                unread_count: c.id === activeConversationId ? 0 : c.unread_count + 1,
+              }
+            : c
+        )
+      );
+      setTypingConversations((prev) => {
+        const next = new Set(prev);
+        next.delete(message.conversationId);
+        return next;
+      });
+    },
+    [activeConversationId]
+  );
 
-  /** Call this when the server confirms delivery/read status */
   const handleStatusUpdate = useCallback(
     (conversationId: string, messageId: string, status: MessageStatus) => {
       setMessages((prev) => ({
@@ -274,59 +165,6 @@ export const useMessages = () => {
     []
   );
 
-  // ── Conversation selection ────────────────────────────────────────────────
-
-  const selectConversation = useCallback((conversationId: string) => {
-    setActiveConversationId(conversationId || null);
-    setSearchQuery('');
-    setSearchResults([]);
-
-    if (!conversationId) return;
-
-    setConversations((prev) =>
-      prev.map((c) => (c.id === conversationId ? { ...c, unreadCount: 0 } : c))
-    );
-    setMessages((prev) => ({
-      ...prev,
-      [conversationId]: (prev[conversationId] ?? []).map((m) => ({
-        ...m,
-        read: true,
-        status: m.senderId !== 'learner1' ? ('read' as MessageStatus) : m.status,
-      })),
-    }));
-  }, []);
-
-  // ── Cursor-based pagination ───────────────────────────────────────────────
-
-  const loadMoreMessages = useCallback(async () => {
-    if (!activeConversationId || isLoadingMore || !hasMore[activeConversationId]) return;
-
-    setIsLoadingMore(true);
-    // Simulate network delay
-    await new Promise((r) => setTimeout(r, 600));
-
-    const pool = OLDER_MESSAGES_POOL[activeConversationId] ?? [];
-    const loaded = cursors[activeConversationId] ?? 0;
-    const PAGE = 10;
-    const slice = pool.slice(loaded, loaded + PAGE);
-
-    if (slice.length > 0) {
-      setMessages((prev) => ({
-        ...prev,
-        [activeConversationId]: [...slice, ...(prev[activeConversationId] ?? [])],
-      }));
-      const newLoaded = loaded + slice.length;
-      setCursors((prev) => ({ ...prev, [activeConversationId]: newLoaded }));
-      if (newLoaded >= pool.length) {
-        setHasMore((prev) => ({ ...prev, [activeConversationId]: false }));
-      }
-    } else {
-      setHasMore((prev) => ({ ...prev, [activeConversationId]: false }));
-    }
-
-    setIsLoadingMore(false);
-  }, [activeConversationId, isLoadingMore, hasMore, cursors]);
-
   // ── Optimistic send ───────────────────────────────────────────────────────
 
   const sendMessage = useCallback(
@@ -337,7 +175,7 @@ export const useMessages = () => {
       const optimisticMsg: EnhancedMessage = {
         id: tempId,
         conversationId: activeConversationId,
-        senderId: 'learner1',
+        senderId: 'me',
         senderName: 'You',
         content: content.trim(),
         timestamp: new Date().toISOString(),
@@ -353,40 +191,38 @@ export const useMessages = () => {
         })),
       };
 
-      // Store previous state for rollback
       const prevMessages = { ...messages };
       const prevConversations = [...conversations];
 
-      // Optimistic update
       setMessages((current) => ({
         ...current,
-        [activeConversationId]: [...(current[activeConversationId] || []), newMessage],
+        [activeConversationId]: [...(current[activeConversationId] ?? []), optimisticMsg],
       }));
       setConversations((prev) =>
         prev.map((c) =>
           c.id === activeConversationId
-            ? { ...c, lastMessage: optimisticMsg, updatedAt: optimisticMsg.timestamp }
+            ? { ...c, last_message_body: optimisticMsg.content, last_message_at: optimisticMsg.timestamp }
             : c
         )
       );
 
       try {
-        // Simulate API call
-        await new Promise((resolve, reject) => {
-          setTimeout(() => {
-            // Randomly fail 10% of the time for demonstration
-            if (Math.random() < 0.1) reject(new Error('Network error: Failed to send message'));
-            else resolve(true);
-          }, 1000);
+        const res = await messagingService.sendMessage({
+          conversationId: activeConversationId,
+          content: content.trim(),
+          attachments,
         });
+        const confirmed = res.data as EnhancedMessage;
+        setMessages((current) => ({
+          ...current,
+          [activeConversationId]: (current[activeConversationId] ?? []).map((m) =>
+            m.id === tempId ? { ...confirmed, status: 'sent' } : m
+          ),
+        }));
       } catch (err) {
-        // Rollback on failure
         setMessages(prevMessages);
         setConversations(prevConversations);
         setError(err instanceof Error ? err.message : 'Failed to send message');
-        
-        // In a real app, you would use a toast notification here
-        console.error('Optimistic update failed, rolled back:', err);
       }
     },
     [activeConversationId, messages, conversations]
@@ -414,28 +250,8 @@ export const useMessages = () => {
     setSearchResults([]);
   }, []);
 
-  // ── Create conversation ───────────────────────────────────────────────────
+  // ── Cleanup ───────────────────────────────────────────────────────────────
 
-  const createConversation = useCallback(
-    (participantId: string, participantName: string, participantAvatar?: string) => {
-      const newConv: Conversation = {
-        id: `conv-${Date.now()}`,
-        participantId,
-        participantName,
-        participantAvatar,
-        participantOnline: false,
-        unreadCount: 0,
-        updatedAt: new Date().toISOString(),
-      };
-      setConversations((prev) => [newConv, ...prev]);
-      setMessages((prev) => ({ ...prev, [newConv.id]: [] }));
-      setHasMore((prev) => ({ ...prev, [newConv.id]: false }));
-      return newConv;
-    },
-    []
-  );
-
-  // Cleanup typing timers on unmount
   useEffect(() => {
     return () => {
       Object.values(typingTimers.current).forEach(clearTimeout);
@@ -454,13 +270,11 @@ export const useMessages = () => {
     isLoadingMore,
     error,
     isTyping,
-    hasMore: activeConversationId ? (hasMore[activeConversationId] ?? false) : false,
     selectConversation,
     sendMessage,
     searchMessages,
     clearSearch,
-    createConversation,
-    loadMoreMessages,
+    markConversationRead,
     handleRemoteTyping,
     handleIncomingMessage,
     handleStatusUpdate,

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -3,6 +3,7 @@ import { useMessages } from '../hooks/useMessages';
 import ConversationList from '../components/messaging/ConversationList';
 import MessageThread from '../components/messaging/MessageThread';
 import MessageInput from '../components/messaging/MessageInput';
+import UserAvatar from '../components/ui/UserAvatar';
 import { SkeletonCard } from '../components/animations/SkeletonLoader';
 import { useMinimumLoading } from '../hooks/useMinimumLoading';
 
@@ -20,7 +21,7 @@ const Messages: React.FC = () => {
     sendMessage,
     searchMessages,
     clearSearch,
-    createConversation,
+    markConversationRead,
   } = useMessages();
 
   const [isLoading, setIsLoading] = useState(true);
@@ -86,29 +87,17 @@ const Messages: React.FC = () => {
                     </button>
 
                     <div className="relative">
-                      {activeConversation.participantAvatar ? (
-                        <img
-                          src={activeConversation.participantAvatar}
-                          alt={activeConversation.participantName}
-                          className="w-10 h-10 rounded-full object-cover"
-                        />
-                      ) : (
-                        <div className="w-10 h-10 rounded-full bg-stellar flex items-center justify-center text-white font-bold">
-                          {activeConversation.participantName[0]}
-                        </div>
-                      )}
-                      {activeConversation.participantOnline && (
-                        <span className="absolute bottom-0 right-0 w-2.5 h-2.5 bg-emerald-500 border-2 border-white rounded-full" />
-                      )}
+                      <UserAvatar
+                        avatarUrl={activeConversation.other_user_avatar}
+                        name={activeConversation.other_user_name}
+                        size="sm"
+                      />
                     </div>
 
                     <div className="flex-1 min-w-0">
                       <h2 className="text-sm font-bold text-gray-900 truncate">
-                        {activeConversation.participantName}
+                        {activeConversation.other_user_name}
                       </h2>
-                      <p className="text-xs text-gray-500">
-                        {activeConversation.participantOnline ? 'Online' : 'Offline'}
-                      </p>
                     </div>
 
                     {/* Search */}

--- a/src/services/messaging.service.ts
+++ b/src/services/messaging.service.ts
@@ -24,13 +24,11 @@ export interface MessageAttachment {
 
 export interface Conversation {
   id: string;
-  participantId: string;
-  participantName: string;
-  participantAvatar?: string;
-  participantOnline: boolean;
-  lastMessage?: Message;
-  unreadCount: number;
-  updatedAt: string;
+  other_user_name: string;
+  other_user_avatar: string | null;
+  last_message_body: string | null;
+  unread_count: number;
+  last_message_at: string | null;
 }
 
 export interface SendMessageRequest {
@@ -46,7 +44,7 @@ export interface SearchMessagesRequest {
 
 export default class MessagingService {
   async getConversations(opts?: RequestOptions) {
-    return request<Conversation[]>(
+    return request<{ conversations: Conversation[] }>(
       {
         method: "GET",
         url: apiConfig.url.conversations,
@@ -101,7 +99,7 @@ export default class MessagingService {
   async markAsRead(conversationId: string, opts?: RequestOptions) {
     return request<{ success: boolean }>(
       {
-        method: "PUT",
+        method: "POST",
         url: `${apiConfig.url.conversations}/${conversationId}/read`,
       },
       opts,


### PR DESCRIPTION
 Align conversation list UI with server API shape
  
  Updates the messaging UI to consume the flat { conversations: [...] } response from ConversationsController.list
   without pagination.
  
  Changes
  
  - Conversation type updated to server field names (other_user_name, other_user_avatar, last_message_body,
  unread_count, last_message_at)
  - getConversations() unwraps data.conversations; markAsRead changed to POST /conversations/:id/read
  - Unread badge hidden when unread_count === 0
  - last_message_body === null renders italic "No messages yet"
  - last_message_body === '[Message deleted]' renders italic grey text
  - other_user_avatar === null falls back to UserAvatar initials
  - Selecting a conversation calls markConversationRead, which zeroes unread_count in local state immediately — no
  full list refetch

closes #318 