### PR TITLE
feat: partial-update pricing and availability with optimistic UI

### DIFF
--- a/src/components/mentor/AvailabilityCalendar.tsx
+++ b/src/components/mentor/AvailabilityCalendar.tsx
@@ -1,52 +1,128 @@
 import { useState } from 'react';
+import Button from '../ui/Button';
+import { useAvailabilityUpdate } from '../../hooks/queries/useMentors';
+import type { AvailabilitySchedule } from '../../services/mentor.service';
 
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const HOURS = Array.from({ length: 12 }, (_, i) => `${i + 8}:00`);
 
-type Slot = { day: string; hour: string };
+interface AvailabilityCalendarProps {
+  mentorId: string;
+  initialSchedule?: AvailabilitySchedule;
+  initialIsAvailable?: boolean;
+  onScheduleChange: (schedule: AvailabilitySchedule, isAvailable: boolean) => void;
+}
 
-export default function AvailabilityCalendar() {
-  const [slots, setSlots] = useState<Slot[]>([]);
+function scheduleToSlots(schedule: AvailabilitySchedule): Set<string> {
+  const set = new Set<string>();
+  for (const [day, hours] of Object.entries(schedule)) {
+    hours.forEach((h) => set.add(`${day}-${h}`));
+  }
+  return set;
+}
+
+function slotsToSchedule(slots: Set<string>): AvailabilitySchedule {
+  const schedule: AvailabilitySchedule = {};
+  slots.forEach((key) => {
+    const [day, hour] = key.split(/-(?=\d)/);
+    if (!schedule[day]) schedule[day] = [];
+    schedule[day].push(hour);
+  });
+  return schedule;
+}
+
+export default function AvailabilityCalendar({
+  mentorId,
+  initialSchedule = {},
+  initialIsAvailable = true,
+  onScheduleChange,
+}: AvailabilityCalendarProps) {
+  const [slots, setSlots] = useState<Set<string>>(() => scheduleToSlots(initialSchedule));
+  const [isAvailable, setIsAvailable] = useState(initialIsAvailable);
+
+  const { save, saving } = useAvailabilityUpdate(mentorId, onScheduleChange);
 
   const toggle = (day: string, hour: string) => {
     const key = `${day}-${hour}`;
-    setSlots(prev =>
-      prev.some(s => `${s.day}-${s.hour}` === key)
-        ? prev.filter(s => `${s.day}-${s.hour}` !== key)
-        : [...prev, { day, hour }]
-    );
+    setSlots((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
   };
 
-  const isActive = (day: string, hour: string) =>
-    slots.some(s => s.day === day && s.hour === hour);
+  const handleSave = async () => {
+    const schedule = slotsToSchedule(slots);
+    const prevSlots = new Set(slots);
+    const prevIsAvailable = isAvailable;
+
+    // Optimistic update
+    onScheduleChange(schedule, isAvailable);
+
+    await save(schedule, isAvailable, () => {
+      // Rollback
+      setSlots(prevSlots);
+      setIsAvailable(prevIsAvailable);
+      onScheduleChange(slotsToSchedule(prevSlots), prevIsAvailable);
+    });
+  };
 
   return (
-    <div className="overflow-x-auto">
-      <table className="text-xs border-collapse w-full">
-        <thead>
-          <tr>
-            <th className="w-14 p-2 text-gray-400 font-normal" />
-            {DAYS.map(d => <th key={d} className="p-2 text-gray-600 font-medium">{d}</th>)}
-          </tr>
-        </thead>
-        <tbody>
-          {HOURS.map(h => (
-            <tr key={h}>
-              <td className="p-2 text-gray-400 text-right pr-3">{h}</td>
-              {DAYS.map(d => (
-                <td key={d} className="p-1">
-                  <button
-                    onClick={() => toggle(d, h)}
-                    className={`w-full h-7 rounded transition-colors
-                      ${isActive(d, h) ? 'bg-indigo-500 hover:bg-indigo-600' : 'bg-gray-100 hover:bg-gray-200'}`}
-                  />
-                </td>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold text-gray-900">Availability</h3>
+        <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isAvailable}
+            onChange={(e) => setIsAvailable(e.target.checked)}
+            className="rounded"
+          />
+          Available for bookings
+        </label>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="text-xs border-collapse w-full">
+          <thead>
+            <tr>
+              <th className="w-14 p-2 text-gray-400 font-normal" />
+              {DAYS.map((d) => (
+                <th key={d} className="p-2 text-gray-600 font-medium">{d}</th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
-      <p className="text-xs text-gray-500 mt-3">{slots.length} slot{slots.length !== 1 ? 's' : ''} selected</p>
+          </thead>
+          <tbody>
+            {HOURS.map((h) => (
+              <tr key={h}>
+                <td className="p-2 text-gray-400 text-right pr-3">{h}</td>
+                {DAYS.map((d) => (
+                  <td key={d} className="p-1">
+                    <button
+                      onClick={() => toggle(d, h)}
+                      className={`w-full h-7 rounded transition-colors ${
+                        slots.has(`${d}-${h}`)
+                          ? 'bg-indigo-500 hover:bg-indigo-600'
+                          : 'bg-gray-100 hover:bg-gray-200'
+                      }`}
+                      aria-label={`${slots.has(`${d}-${h}`) ? 'Deselect' : 'Select'} ${d} ${h}`}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-500">
+          {slots.size} slot{slots.size !== 1 ? 's' : ''} selected
+        </p>
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving…' : 'Save Availability'}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/mentor/PricingSettings.tsx
+++ b/src/components/mentor/PricingSettings.tsx
@@ -1,33 +1,63 @@
 import { useState } from 'react';
-import Input from '../ui/Input';
-import Select from '../forms/Select';
 import Button from '../ui/Button';
-import type { AssetType } from '../../types';
+import { usePricingUpdate } from '../../hooks/queries/useMentors';
 
-const ASSETS = [
-  { value: 'XLM', label: 'XLM - Stellar Lumens' },
-  { value: 'USDC', label: 'USDC - USD Coin' },
-  { value: 'PYUSD', label: 'PYUSD - PayPal USD' },
-];
+interface PricingSettingsProps {
+  mentorId: string;
+  initialRate: number;
+  onRateChange: (rate: number) => void;
+}
 
-export default function PricingSettings() {
-  const [rate, setRate] = useState('100');
-  const [asset, setAsset] = useState<AssetType>('USDC');
-  const [saved, setSaved] = useState(false);
+export default function PricingSettings({ mentorId, initialRate, onRateChange }: PricingSettingsProps) {
+  const [input, setInput] = useState(String(initialRate));
+  const [error, setError] = useState<string | null>(null);
 
-  const save = () => { setSaved(true); setTimeout(() => setSaved(false), 2000); };
+  const { save, saving } = usePricingUpdate(mentorId, onRateChange);
+
+  const handleSave = async () => {
+    const parsed = parseFloat(input);
+    if (!isFinite(parsed) || parsed <= 0) {
+      setError('Enter a positive number greater than 0');
+      return;
+    }
+    setError(null);
+
+    const prev = initialRate;
+    // Optimistic update
+    onRateChange(parsed);
+
+    await save(parsed, () => {
+      // Rollback
+      onRateChange(prev);
+      setInput(String(prev));
+    });
+  };
 
   return (
     <div className="space-y-4">
       <h3 className="font-semibold text-gray-900">Pricing</h3>
-      <div className="grid grid-cols-2 gap-4">
-        <Input label="Hourly Rate" type="number" value={rate} onChange={e => setRate(e.target.value)} />
-        <Select label="Currency" options={ASSETS} value={asset} onChange={v => setAsset(v as AssetType)} />
+
+      <div className="space-y-1">
+        <label className="block text-sm font-medium text-gray-700">Hourly Rate (USD)</label>
+        <input
+          type="number"
+          min="0.01"
+          step="0.01"
+          value={input}
+          onChange={(e) => { setInput(e.target.value); setError(null); }}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          placeholder="e.g. 25.50"
+        />
+        {error && <p className="text-xs text-red-600">{error}</p>}
       </div>
+
       <div className="bg-indigo-50 rounded-lg p-3 text-sm text-indigo-700">
-        Learners will pay <strong>{rate} {asset}</strong>/hour. Platform fee (5%) is deducted automatically.
+        Learners will pay <strong>${input || '—'}/hr</strong>. Platform fee (5%) is deducted automatically.
       </div>
-      <Button onClick={save}>{saved ? '✓ Saved' : 'Save Pricing'}</Button>
+
+      <Button onClick={handleSave} disabled={saving}>
+        {saving ? 'Saving…' : 'Save Pricing'}
+      </Button>
     </div>
   );
 }

--- a/src/hooks/queries/useMentors.ts
+++ b/src/hooks/queries/useMentors.ts
@@ -1,4 +1,7 @@
 import { useState, useCallback } from 'react';
+import { updatePricing, updateAvailability } from '../../services/mentor.service';
+import type { AvailabilitySchedule } from '../../services/mentor.service';
+import { showErrorToast } from '../../utils/toast.utils';
 
 export interface MentorProfile {
   id?: string;
@@ -111,3 +114,62 @@ export const useMentorProfile = () => {
     removePortfolioItem,
   };
 };
+
+// ─── Partial-update hooks ─────────────────────────────────────────────────────
+
+export function usePricingUpdate(
+  mentorId: string,
+  onSuccess: (hourlyRate: number) => void,
+) {
+  const [saving, setSaving] = useState(false);
+
+  const save = useCallback(
+    async (hourlyRate: number, onRollback: () => void) => {
+      setSaving(true);
+      try {
+        const result = await updatePricing(mentorId, hourlyRate);
+        onSuccess(result.hourlyRate);
+      } catch (err) {
+        onRollback();
+        showErrorToast(err instanceof Error ? err.message : 'Failed to update pricing');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [mentorId, onSuccess],
+  );
+
+  return { save, saving };
+}
+
+export function useAvailabilityUpdate(
+  mentorId: string,
+  onSuccess: (schedule: AvailabilitySchedule, isAvailable: boolean) => void,
+) {
+  const [saving, setSaving] = useState(false);
+
+  const save = useCallback(
+    async (
+      schedule: AvailabilitySchedule,
+      isAvailable: boolean,
+      onRollback: () => void,
+    ) => {
+      setSaving(true);
+      try {
+        const result = await updateAvailability(mentorId, {
+          availability_schedule: schedule,
+          is_available: isAvailable,
+        });
+        onSuccess(result.availability_schedule, result.is_available);
+      } catch (err) {
+        onRollback();
+        showErrorToast(err instanceof Error ? err.message : 'Failed to update availability');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [mentorId, onSuccess],
+  );
+
+  return { save, saving };
+}

--- a/src/pages/MentorProfile.tsx
+++ b/src/pages/MentorProfile.tsx
@@ -2,13 +2,32 @@ import { useState } from 'react';
 import Input from '../components/ui/Input';
 import Button from '../components/ui/Button';
 import FileUpload from '../components/forms/FileUpload';
+import ProfileHeader from '../components/mentor/ProfileHeader';
 import PricingSettings from '../components/mentor/PricingSettings';
 import AvailabilityCalendar from '../components/mentor/AvailabilityCalendar';
+import type { AvailabilitySchedule } from '../services/mentor.service';
+
+// In a real app this would come from auth context / route params
+const MENTOR_ID = 'me';
+
+interface ProfileState {
+  name: string;
+  bio: string;
+  skills: string;
+  hourlyRate: number;
+  availabilitySchedule: AvailabilitySchedule;
+  isAvailable: boolean;
+}
 
 export default function MentorProfile() {
-  const [name, setName] = useState('Alice Chen');
-  const [bio, setBio] = useState('Senior Rust & Blockchain engineer with 8 years experience.');
-  const [skills, setSkills] = useState('Rust, Soroban, Stellar');
+  const [profile, setProfile] = useState<ProfileState>({
+    name: 'Alice Chen',
+    bio: 'Senior Rust & Blockchain engineer with 8 years experience.',
+    skills: 'Rust, Soroban, Stellar',
+    hourlyRate: 100,
+    availabilitySchedule: {},
+    isAvailable: true,
+  });
   const [saved, setSaved] = useState(false);
 
   const save = () => { setSaved(true); setTimeout(() => setSaved(false), 2000); };
@@ -17,26 +36,59 @@ export default function MentorProfile() {
     <div className="space-y-8 max-w-2xl">
       <h1 className="text-2xl font-bold text-gray-900">My Profile</h1>
 
+      <ProfileHeader
+        name={profile.name}
+        bio={profile.bio}
+        hourlyRate={profile.hourlyRate}
+        currency="USD"
+        joinDate="2024"
+        sessionCount={0}
+        learnerCount={0}
+        verificationStatus="pending"
+      />
+
       <section className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
         <h2 className="font-semibold text-gray-900">Basic Info</h2>
         <FileUpload label="Profile Photo" accept="image/*" onFile={() => {}} />
-        <Input label="Full Name" value={name} onChange={e => setName(e.target.value)} />
+        <Input
+          label="Full Name"
+          value={profile.name}
+          onChange={(e) => setProfile((p) => ({ ...p, name: e.target.value }))}
+        />
         <div className="space-y-1">
           <label className="block text-sm font-medium text-gray-700">Bio</label>
-          <textarea value={bio} onChange={e => setBio(e.target.value)} rows={3}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none" />
+          <textarea
+            value={profile.bio}
+            onChange={(e) => setProfile((p) => ({ ...p, bio: e.target.value }))}
+            rows={3}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+          />
         </div>
-        <Input label="Skills (comma separated)" value={skills} onChange={e => setSkills(e.target.value)} />
+        <Input
+          label="Skills (comma separated)"
+          value={profile.skills}
+          onChange={(e) => setProfile((p) => ({ ...p, skills: e.target.value }))}
+        />
         <Button onClick={save}>{saved ? '✓ Saved' : 'Save Changes'}</Button>
       </section>
 
       <section className="bg-white rounded-xl border border-gray-200 p-6">
-        <PricingSettings />
+        <PricingSettings
+          mentorId={MENTOR_ID}
+          initialRate={profile.hourlyRate}
+          onRateChange={(rate) => setProfile((p) => ({ ...p, hourlyRate: rate }))}
+        />
       </section>
 
-      <section className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
-        <h2 className="font-semibold text-gray-900">Availability</h2>
-        <AvailabilityCalendar />
+      <section className="bg-white rounded-xl border border-gray-200 p-6">
+        <AvailabilityCalendar
+          mentorId={MENTOR_ID}
+          initialSchedule={profile.availabilitySchedule}
+          initialIsAvailable={profile.isAvailable}
+          onScheduleChange={(schedule, isAvailable) =>
+            setProfile((p) => ({ ...p, availabilitySchedule: schedule, isAvailable }))
+          }
+        />
       </section>
     </div>
   );

--- a/src/services/mentor.service.ts
+++ b/src/services/mentor.service.ts
@@ -93,3 +93,29 @@ export async function getMentorAvailability(id: string): Promise<AvailabilitySlo
   const { data } = await api.get(`/mentors/${id}/availability`);
   return data.data;
 }
+
+export interface PricingResponse {
+  hourlyRate: number;
+}
+
+export async function updatePricing(id: string, hourlyRate: number): Promise<PricingResponse> {
+  const { data } = await api.put(`/mentors/${id}/pricing`, { hourlyRate });
+  return data.data;
+}
+
+export interface AvailabilitySchedule {
+  [day: string]: string[];
+}
+
+export interface AvailabilityResponse {
+  availability_schedule: AvailabilitySchedule;
+  is_available: boolean;
+}
+
+export async function updateAvailability(
+  id: string,
+  payload: { availability_schedule: AvailabilitySchedule; is_available: boolean },
+): Promise<AvailabilityResponse> {
+  const { data } = await api.post(`/mentors/${id}/availability`, payload);
+  return data.data;
+}


### PR DESCRIPTION
 Partial-update pricing and availability with optimistic UI
  
  Updates the mentor profile page to correctly handle the partial responses from PUT /mentors/:id/pricing and POST
  /mentors/:id/availability — neither endpoint returns the full mentor record.
  
  Changes
  
  - mentor.service.ts — added updatePricing and updateAvailability typed to their actual response shapes ({ hourlyRate
  } and { availability_schedule, is_available })
  - usePricingUpdate / useAvailabilityUpdate hooks — each applies the optimistic update immediately, then reconciles
  with the server response; on network error, calls onRollback and shows an error toast without replacing the full
  profile object
  - PricingSettings — type="number" step="0.01" input; validates the value is a finite positive number before
  submitting; shows inline error if not
  - AvailabilityCalendar — saves only availability_schedule + is_available back to state on success; rolls back both
  local slot state and parent state on failure; adds an "Available for bookings" toggle
  - MentorProfile — owns a single ProfileState; ProfileHeader reads hourlyRate directly from it, so the displayed rate
  updates the moment onRateChange fires — no full page refetch needed

closes #316 