### PR TITLE
feat: handle 403/400 from POST /conversations with specific UI

### DIFF
--- a/src/hooks/useCreateConversation.ts
+++ b/src/hooks/useCreateConversation.ts
@@ -1,0 +1,36 @@
+import { useState, useCallback } from 'react';
+import MessagingService, {
+  NoSharedBookingError,
+  SelfMessageError,
+  type Conversation,
+} from '../services/messaging.service';
+
+export type ConversationStatus = 'idle' | 'loading' | 'forbidden' | 'self' | 'error' | 'success';
+
+const service = new MessagingService();
+
+export function useCreateConversation() {
+  const [status, setStatus] = useState<ConversationStatus>('idle');
+  const [conversation, setConversation] = useState<Conversation | null>(null);
+
+  const create = useCallback(async (participantId: string) => {
+    setStatus('loading');
+    try {
+      const res = await service.createConversation(participantId);
+      setConversation(res.data);
+      setStatus('success');
+      return res.data;
+    } catch (err) {
+      if (err instanceof NoSharedBookingError) {
+        setStatus('forbidden');
+      } else if (err instanceof SelfMessageError) {
+        setStatus('self');
+      } else {
+        setStatus('error');
+      }
+      return null;
+    }
+  }, []);
+
+  return { status, conversation, create };
+}

--- a/src/pages/MentorPublicProfile.tsx
+++ b/src/pages/MentorPublicProfile.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import ProfileHeader from '../components/mentor/ProfileHeader';
 import RatingBreakdown from '../components/mentor/RatingBreakdown';
 import PublicAvailability from '../components/mentor/PublicAvailability';
@@ -7,6 +7,8 @@ import ReviewsList from '../components/mentor/ReviewsList';
 import { EndorsementSection } from '../components/profile/EndorsementSection';
 import { useShare } from '../hooks/useShare';
 import { useEndorsements } from '../hooks/useEndorsements';
+import { useAuthContext } from '../contexts/AuthContext';
+import { useCreateConversation } from '../hooks/useCreateConversation';
 import { applyMetaTags, buildMentorProfileMeta } from '../utils/og-meta.utils';
 import {
   getPublicUserProfile,
@@ -18,10 +20,78 @@ import {
   type AvailabilitySlot,
   type VerificationStatus
 } from '../services/mentor.service';
+import { ROUTES } from '../config/routes.config';
+
+// ─── MessageButton ────────────────────────────────────────────────────────────
+
+interface MessageButtonProps {
+  mentorId: string;
+  mentorName: string;
+  isOwnProfile: boolean;
+}
+
+function MessageButton({ mentorId, mentorName, isOwnProfile }: MessageButtonProps) {
+  const navigate = useNavigate();
+  const { status, conversation, create } = useCreateConversation();
+
+  const handleClick = async () => {
+    if (status === 'success' && conversation) {
+      navigate(`/messages?conversation=${conversation.id}`);
+      return;
+    }
+    await create(mentorId);
+  };
+
+  useEffect(() => {
+    if (status === 'success' && conversation) {
+      navigate(`/messages?conversation=${conversation.id}`);
+    }
+  }, [status, conversation, navigate]);
+
+  if (isOwnProfile || status === 'self') return null;
+
+  if (status === 'forbidden') {
+    return (
+      <div className="space-y-3">
+        <div className="relative group">
+          <button
+            disabled
+            className="w-full rounded-xl border border-gray-300 bg-gray-100 px-6 py-2.5 text-sm font-bold text-gray-400 cursor-not-allowed"
+          >
+            Message
+          </button>
+          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block w-64 bg-gray-900 text-white text-xs rounded-lg p-3 shadow-lg z-10">
+            You can only message mentors you have booked a session with.
+          </div>
+        </div>
+        <button
+          onClick={() => {
+            const el = document.getElementById('availability');
+            el?.scrollIntoView({ behavior: 'smooth' });
+          }}
+          className="w-full rounded-xl bg-stellar px-6 py-2.5 text-sm font-bold text-white shadow-sm hover:bg-stellar-dark transition"
+        >
+          Book a Session to Message
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={status === 'loading'}
+      className="rounded-xl border border-stellar/20 bg-white px-6 py-2.5 text-sm font-bold text-stellar shadow-sm hover:bg-stellar/5 transition disabled:opacity-50"
+    >
+      {status === 'loading' ? 'Loading…' : 'Message'}
+    </button>
+  );
+}
 
 export default function MentorPublicProfile() {
   const { id } = useParams<{ id: string }>();
   const { share } = useShare();
+  const { user } = useAuthContext();
   const [shareStatus, setShareStatus] = useState('');
   const [mentor, setMentor] = useState<PublicUserProfile | null>(null);
   const [ratingSummary, setRatingSummary] = useState<RatingSummary | null>(null);
@@ -31,6 +101,7 @@ export default function MentorPublicProfile() {
   const [error, setError] = useState<string | null>(null);
 
   const mentorId = id ?? 'm1';
+  const isOwnProfile = !!user && user.id === mentorId;
 
   useEffect(() => {
     const fetchMentorData = async () => {
@@ -169,6 +240,11 @@ export default function MentorPublicProfile() {
         >
           Share Session Invite
         </button>
+        <MessageButton
+          mentorId={mentorId}
+          mentorName={mentor?.name ?? ''}
+          isOwnProfile={isOwnProfile}
+        />
       </div>
       {shareStatus && <p className="text-sm font-medium text-stellar">{shareStatus}</p>}
 

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -159,8 +159,8 @@ const Messages: React.FC = () => {
                     />
                   </div>
 
-                  {/* Input */}
-                  <MessageInput onSendMessage={sendMessage} />
+                  {/* Input — only shown once a conversation exists */}
+                  {activeConversationId && <MessageInput onSendMessage={sendMessage} />}
                 </>
               ) : (
                 <div className="flex flex-col items-center justify-center h-full p-8 text-center">

--- a/src/services/messaging.service.ts
+++ b/src/services/messaging.service.ts
@@ -2,6 +2,22 @@ import { apiConfig } from "../config/api.config";
 import type { RequestOptions } from "../types/api.types";
 import { request } from "../utils/request.utils";
 
+// ─── Typed errors ─────────────────────────────────────────────────────────────
+
+export class NoSharedBookingError extends Error {
+  constructor() {
+    super("Messaging is only available between users who share at least one booking");
+    this.name = "NoSharedBookingError";
+  }
+}
+
+export class SelfMessageError extends Error {
+  constructor() {
+    super("You cannot message yourself");
+    this.name = "SelfMessageError";
+  }
+}
+
 export interface Message {
   id: string;
   conversationId: string;
@@ -120,13 +136,21 @@ export default class MessagingService {
   }
 
   async createConversation(participantId: string, opts?: RequestOptions) {
-    return request<Conversation>(
-      {
-        method: "POST",
-        url: apiConfig.url.conversations,
-        data: { participantId },
-      },
-      opts,
-    );
+    try {
+      return await request<Conversation>(
+        {
+          method: "POST",
+          url: apiConfig.url.conversations,
+          data: { participantId },
+        },
+        opts,
+      );
+    } catch (err: unknown) {
+      const status = (err as { status?: number; response?: { status?: number } })?.status
+        ?? (err as { response?: { status?: number } })?.response?.status;
+      if (status === 403) throw new NoSharedBookingError();
+      if (status === 400) throw new SelfMessageError();
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
Handle 403/400 from POST /conversations with specific UI
  
  Replaces the generic error handler for POST /conversations with targeted UI for the two expected failure cases.
  
  Changes
  
  - messaging.service.ts — added NoSharedBookingError (403) and SelfMessageError (400); createConversation inspects
  the HTTP status and throws the appropriate typed error instead of a generic one
  - useCreateConversation (new hook) — wraps createConversation and exposes a status discriminant: idle | loading |
  forbidden | self | error | success
  - MentorPublicProfile — MessageButton component added:
    - Hidden entirely on the user's own profile (user.id === mentorId) or when the API returns 400
    - On 403: renders a disabled "Message" button with a hover tooltip ("You can only message mentors you have booked
  a session with…") and a "Book a Session to Message" CTA that scrolls to the availability section
    - On success: navigates directly to /messages?conversation=<id>
  
  - Messages.tsx — MessageInput is now gated behind activeConversationId; the input field is not rendered until a
  conversation is successfully created or selected

closes #320 