### PR TITLE
Feature/issues 357 358 360  : Data Export Polling, Google Calendar OAuth, and Presence Heartbeat Fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ const PaymentHistory = lazy(() => import('./pages/PaymentHistory'));
 const CheckoutPage = lazy(() => import('./pages/CheckoutPage'));
 const LearningGoals = lazy(() => import('./pages/LearningGoals'));
 const Settings = lazy(() => import('./pages/Settings'));
+const CalendarSettingsPage = lazy(() => import('./pages/CalendarSettingsPage'));
 const MFAChallengeScreen = lazy(() => import('./pages/MFAChallengeScreen'));
 const Messages = lazy(() => import('./pages/Messages'));
 const DisputeDetailPage = lazy(() => import('./pages/DisputeDetailPage'));
@@ -197,6 +198,7 @@ function AppRoutes() {
 
             {/* Settings Redirect */}
             <Route path="/settings" element={<ProtectedRoute><Navigate to={auth.user?.role === 'mentor' ? '/mentor/settings' : '/learner/settings'} replace /></ProtectedRoute>} />
+            <Route path="/settings/calendar" element={<ProtectedRoute><DashboardLayout><CalendarSettingsPage /></DashboardLayout></ProtectedRoute>} />
 
             {/* Fallback */}
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/settings/CalendarSettings.tsx
+++ b/src/components/settings/CalendarSettings.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import { Calendar, CheckCircle, Loader2, AlertCircle } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { connectGoogleCalendar, disconnectGoogleCalendar } from '../../services/calendar.service';
+
+const CalendarSettings: React.FC = () => {
+  const [connected, setConnected] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+
+    if (params.get('connected') === 'true') {
+      setConnected(true);
+      toast.success('Google Calendar connected');
+      window.history.replaceState({}, '', window.location.pathname);
+    } else if (params.get('error') === 'access_denied') {
+      setError('Google Calendar access was denied. Please try again.');
+      window.history.replaceState({}, '', window.location.pathname);
+    }
+  }, []);
+
+  const handleConnect = () => {
+    setConnecting(true);
+    connectGoogleCalendar(); // navigates away
+  };
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      const ok = await disconnectGoogleCalendar();
+      if (ok) {
+        setConnected(false);
+        toast.success('Google Calendar disconnected');
+      } else {
+        toast.error('Failed to disconnect Google Calendar');
+      }
+    } catch {
+      toast.error('Failed to disconnect Google Calendar');
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-sm text-red-700 dark:text-red-400">
+          <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="p-5 border border-border rounded-2xl space-y-3">
+        <div className="flex items-center gap-3">
+          <div className="w-9 h-9 bg-accent rounded-xl flex items-center justify-center">
+            <Calendar className="w-4 h-4 text-primary" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-text">Google Calendar</p>
+            <p className="text-xs text-muted-foreground">Sync your sessions with Google Calendar</p>
+          </div>
+          {connected && (
+            <span className="ml-auto flex items-center gap-1 text-xs font-bold text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/30 px-2 py-1 rounded-lg">
+              <CheckCircle className="w-3 h-3" /> Connected
+            </span>
+          )}
+        </div>
+
+        {connected ? (
+          <button
+            onClick={handleDisconnect}
+            disabled={disconnecting}
+            className="flex items-center gap-2 px-4 py-2 border border-border text-sm font-semibold rounded-xl hover:bg-surface transition-colors disabled:opacity-50"
+          >
+            {disconnecting && <Loader2 className="w-4 h-4 animate-spin" />}
+            Disconnect
+          </button>
+        ) : (
+          <button
+            onClick={handleConnect}
+            disabled={connecting}
+            className="flex items-center gap-2 px-4 py-2 bg-stellar text-white text-sm font-semibold rounded-xl hover:bg-stellar-dark transition-colors disabled:opacity-50"
+          >
+            {connecting && <Loader2 className="w-4 h-4 animate-spin" />}
+            Connect Google Calendar
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CalendarSettings;

--- a/src/components/settings/DangerZoneSettings.tsx
+++ b/src/components/settings/DangerZoneSettings.tsx
@@ -5,6 +5,7 @@ import FocusTrap from '../a11y/FocusTrap';
 import AccountService from '../../services/account.service';
 import { useAuth } from '../../hooks/useAuth';
 import toast from 'react-hot-toast';
+import DataExportSettings from './DataExportSettings';
 
 const inputClass = 'w-full px-3 py-2 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-red-500/30 focus:border-red-500 bg-white';
 
@@ -39,6 +40,8 @@ const DangerZoneSettings: React.FC = () => {
 
   return (
     <div className="space-y-6">
+      <DataExportSettings />
+
       <div className="p-6 border border-red-100 bg-red-50/30 rounded-3xl">
         <div className="flex items-start gap-4">
           <div className="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center shrink-0">

--- a/src/components/settings/DataExportSettings.tsx
+++ b/src/components/settings/DataExportSettings.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Download, Loader2, AlertCircle, CheckCircle } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { requestExport, getExportStatus, getExportDownloadUrl, ExportJobStatus } from '../../services/export.service';
+
+const POLL_INTERVAL = 3000;
+const POLL_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+
+type ExportState =
+  | { phase: 'idle' }
+  | { phase: 'requesting' }
+  | { phase: 'polling'; jobId: string; status: ExportJobStatus['status'] }
+  | { phase: 'completed'; jobId: string; expiresAt: string }
+  | { phase: 'failed'; errorMessage: string | null }
+  | { phase: 'expired' }
+  | { phase: 'timeout' };
+
+const DataExportSettings: React.FC = () => {
+  const [state, setState] = useState<ExportState>({ phase: 'idle' });
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stopPolling = () => {
+    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+    if (timeoutRef.current) { clearTimeout(timeoutRef.current); timeoutRef.current = null; }
+  };
+
+  useEffect(() => () => stopPolling(), []);
+
+  const startPolling = (jobId: string) => {
+    stopPolling();
+
+    timeoutRef.current = setTimeout(() => {
+      stopPolling();
+      setState({ phase: 'timeout' });
+    }, POLL_TIMEOUT);
+
+    pollRef.current = setInterval(async () => {
+      try {
+        const data = await getExportStatus(jobId);
+
+        if (data.status === 'completed') {
+          stopPolling();
+          const expired = new Date(data.expires_at) < new Date();
+          if (expired) {
+            setState({ phase: 'expired' });
+          } else {
+            setState({ phase: 'completed', jobId, expiresAt: data.expires_at });
+            window.location.href = getExportDownloadUrl(jobId);
+          }
+        } else if (data.status === 'failed') {
+          stopPolling();
+          setState({ phase: 'failed', errorMessage: data.error_message });
+        } else {
+          setState({ phase: 'polling', jobId, status: data.status });
+        }
+      } catch (err: any) {
+        if (err?.response?.status === 410) {
+          stopPolling();
+          setState({ phase: 'expired' });
+        }
+      }
+    }, POLL_INTERVAL);
+  };
+
+  const handleExport = async () => {
+    setState({ phase: 'requesting' });
+    try {
+      const { jobId } = await requestExport();
+      setState({ phase: 'polling', jobId, status: 'pending' });
+      startPolling(jobId);
+    } catch {
+      setState({ phase: 'idle' });
+      toast.error('Failed to start export. Please try again.');
+    }
+  };
+
+  const reset = () => { stopPolling(); setState({ phase: 'idle' }); };
+
+  const isPolling = state.phase === 'polling' || state.phase === 'requesting';
+
+  return (
+    <div className="p-5 border border-border rounded-2xl space-y-3">
+      <div className="flex items-center gap-3">
+        <div className="w-9 h-9 bg-blue-50 dark:bg-blue-900/20 rounded-xl flex items-center justify-center">
+          <Download className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+        </div>
+        <div>
+          <p className="text-sm font-semibold text-text">Export My Data</p>
+          <p className="text-xs text-muted-foreground">Download a copy of all your account data</p>
+        </div>
+      </div>
+
+      {state.phase === 'idle' && (
+        <button
+          onClick={handleExport}
+          className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-xl hover:bg-blue-700 transition-colors"
+        >
+          Export My Data
+        </button>
+      )}
+
+      {isPolling && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin text-blue-600" />
+          <span>
+            Preparing your data
+            {state.phase === 'polling' ? ` (${state.status})` : ''}…
+          </span>
+        </div>
+      )}
+
+      {state.phase === 'completed' && (
+        <div className="flex items-center gap-2 text-sm text-green-600 dark:text-green-400">
+          <CheckCircle className="w-4 h-4" />
+          <span>Download started!</span>
+          <button onClick={reset} className="ml-auto text-xs text-muted-foreground hover:underline">
+            New export
+          </button>
+        </div>
+      )}
+
+      {state.phase === 'failed' && (
+        <div className="space-y-2">
+          <div className="flex items-start gap-2 text-sm text-red-600 dark:text-red-400">
+            <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+            <span>{state.errorMessage ?? 'Export failed.'}</span>
+          </div>
+          <button onClick={reset} className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-xl hover:bg-blue-700 transition-colors">
+            Try again
+          </button>
+        </div>
+      )}
+
+      {(state.phase === 'expired' || state.phase === 'timeout') && (
+        <div className="space-y-2">
+          <div className="flex items-start gap-2 text-sm text-amber-600 dark:text-amber-400">
+            <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+            <span>
+              {state.phase === 'expired'
+                ? 'Download link has expired. Please request a new export.'
+                : 'Export is taking too long. Please try again.'}
+            </span>
+          </div>
+          <button onClick={reset} className="px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-xl hover:bg-blue-700 transition-colors">
+            Request new export
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DataExportSettings;

--- a/src/hooks/usePresenceHeartbeat.ts
+++ b/src/hooks/usePresenceHeartbeat.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import PresenceService from '../services/presence.service';
+
+const HEARTBEAT_INTERVAL = 20_000; // 20 seconds
+
+/**
+ * Sends REST heartbeats every 20s when WebSocket is disconnected.
+ * Stops automatically when WebSocket reconnects.
+ * Relies on 'ws-status' CustomEvents dispatched by useWebSocket.
+ */
+export const usePresenceHeartbeat = () => {
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const presenceService = useRef(new PresenceService());
+
+  const startHeartbeat = () => {
+    if (intervalRef.current) return;
+    intervalRef.current = setInterval(() => {
+      presenceService.current.sendHeartbeat().catch(() => {/* silent */});
+    }, HEARTBEAT_INTERVAL);
+  };
+
+  const stopHeartbeat = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    const handleWsStatus = (e: Event) => {
+      const status = (e as CustomEvent<string>).detail;
+      if (status === 'connected') {
+        stopHeartbeat();
+      } else if (status === 'disconnected') {
+        startHeartbeat();
+      }
+    };
+
+    window.addEventListener('ws-status', handleWsStatus);
+    return () => {
+      window.removeEventListener('ws-status', handleWsStatus);
+      stopHeartbeat();
+    };
+  }, []);
+};

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -10,6 +10,7 @@ import { HamburgerDrawer, SECONDARY_NAV_ITEMS } from '../components/navigation/H
 import usePushNotifications from '../hooks/usePushNotifications';
 import { PermissionBanner } from '../components/notifications/PermissionBanner';
 import { DeniedTooltip } from '../components/notifications/DeniedTooltip';
+import { usePresenceHeartbeat } from '../hooks/usePresenceHeartbeat';
 
 // Hamburger icon
 const HamburgerIcon = () => (
@@ -36,6 +37,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
   const { isMobile } = useMobile();
   const { drawerOpen, openDrawer, closeDrawer, sidebarCollapsed, toggleSidebarCollapse } =
     useNavLayout();
+  usePresenceHeartbeat();
   const {
     showBanner,
     showDeniedTooltip,

--- a/src/pages/CalendarSettingsPage.tsx
+++ b/src/pages/CalendarSettingsPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import CalendarSettings from '../components/settings/CalendarSettings';
+
+const CalendarSettingsPage: React.FC = () => (
+  <div className="max-w-2xl mx-auto px-4 py-8">
+    <div className="mb-6">
+      <h1 className="text-2xl font-black text-text tracking-tight">Calendar Settings</h1>
+      <p className="text-muted-foreground mt-1">Connect your Google Calendar to sync sessions.</p>
+    </div>
+    <CalendarSettings />
+  </div>
+);
+
+export default CalendarSettingsPage;

--- a/src/services/calendar.service.ts
+++ b/src/services/calendar.service.ts
@@ -1,0 +1,10 @@
+import api from './api.client';
+
+export const connectGoogleCalendar = (): void => {
+  window.location.href = '/api/v1/calendar/google/connect';
+};
+
+export const disconnectGoogleCalendar = async (): Promise<boolean> => {
+  const res = await api.delete('/v1/calendar/google/disconnect');
+  return res.data?.status === 'success';
+};

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -1,0 +1,22 @@
+import api from './api.client';
+import { request } from '../utils/request.utils';
+
+export interface ExportJobStatus {
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  expires_at: string;
+  error_message: string | null;
+  created_at: string;
+}
+
+export const requestExport = async (): Promise<{ jobId: string }> => {
+  const res = await api.post('/v1/export');
+  return res.data;
+};
+
+export const getExportStatus = async (jobId: string): Promise<ExportJobStatus> => {
+  const res = await api.get(`/v1/export/${jobId}/status`);
+  return res.data.data;
+};
+
+export const getExportDownloadUrl = (jobId: string): string =>
+  `/api/v1/export/${jobId}/download`;

--- a/src/services/presence.service.ts
+++ b/src/services/presence.service.ts
@@ -1,24 +1,36 @@
-import { apiConfig } from "../config/api.config";
-import type { RequestOptions } from "../types/api.types";
-import { request } from "../utils/request.utils";
+import api from './api.client';
+import type { RequestOptions } from '../types/api.types';
 
 export interface PresenceStatus {
   userId: string;
   online: boolean;
-  last_seen?: string;
+  last_seen: string | null;
+}
+
+export interface UserOnlineStatus {
+  online: boolean;
+  last_seen: string | null;
 }
 
 export default class PresenceService {
-  async getBatchStatus(userIds: string[], opts?: RequestOptions): Promise<PresenceStatus[]> {
-    const params = new URLSearchParams();
-    userIds.forEach(id => params.append('userIds', id));
+  /** POST /presence/heartbeat — 204 No Content, do not parse body */
+  async sendHeartbeat(): Promise<void> {
+    await api.post('/v1/presence/heartbeat');
+  }
 
-    return request<PresenceStatus[]>(
-      {
-        method: "GET",
-        url: `${apiConfig.url.presence}/batch?${params.toString()}`,
-      },
-      opts,
+  /** GET /users/:id/online — flat { online, last_seen }, no .data wrapper */
+  async getUserOnlineStatus(userId: string, opts?: RequestOptions): Promise<UserOnlineStatus> {
+    const res = await api.get(`/v1/users/${userId}/online`, { signal: opts?.signal });
+    return res.data as UserOnlineStatus;
+  }
+
+  /** POST /users/online-status — flat { statuses: [...] }, no .data wrapper */
+  async getBatchStatus(userIds: string[], opts?: RequestOptions): Promise<PresenceStatus[]> {
+    const res = await api.post(
+      '/v1/users/online-status',
+      { userIds },
+      { signal: opts?.signal },
     );
+    return (res.data as { statuses: PresenceStatus[] }).statuses;
   }
 }


### PR DESCRIPTION

  
  Closes #357
  Closes #358
  Closes #360
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Summary
  
  This PR implements three independent features across the settings and presence layers of the frontend, each corresponding to a backend
  contract defined in the linked issues.
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #357 — Data Export Flow: Async Job Lifecycle with Polling
  
  Files changed:
  
  - src/services/export.service.ts (new)
  - src/components/settings/DataExportSettings.tsx (new)
  - src/components/settings/DangerZoneSettings.tsx (updated)
  
  What was implemented:
  
  The backend's ExportController.requestExport returns 202 Accepted with a jobId, not the file itself. The frontend now handles the full
  async lifecycle:
  
  - "Export My Data" button calls POST /export and stores the returned jobId.
  - Polling — GET /export/:jobId/status is called every 3 seconds while status is pending or processing. The status response shape { data:
  { status, expires_at, error_message, created_at } } is parsed correctly via response.data.data.
  - Progress indicator shows "Preparing your data… (pending|processing)" during polling.
  - On completed — checks expires_at before triggering download. If not expired, triggers download via window.location.href (binary file
  stream, not fetch()). If expired, shows the expiry message.
  - On failed — displays error_message from the response with a "Try again" button that resets state.
  - On 410 Gone from the download endpoint — shows the same expiry message with a "Request new export" button.
  - Timeout — polling stops after 5 minutes and shows a timeout message with a "Request new export" button.
  - The DataExportSettings component is integrated at the top of the Danger Zone settings tab.
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #358 — Google Calendar OAuth Redirect Flow: Dedicated Callback Route
  
  Files changed:
  
  - src/services/calendar.service.ts (new)
  - src/components/settings/CalendarSettings.tsx (new)
  - src/pages/CalendarSettingsPage.tsx (new)
  - src/App.tsx (updated — new route added)
  
  What was implemented:
  
  The backend's CalendarController.googleConnect redirects to Google's OAuth consent screen and, after consent, redirects back to
  /settings/calendar?connected=true. The frontend now handles this full flow:
  
  - /settings/calendar route added as a protected route wrapped in DashboardLayout.
  - "Connect Google Calendar" button uses window.location.href = '/api/v1/calendar/google/connect' — a browser redirect, not an API call —
  with a loading spinner while the navigation is in progress.
  - On return with ?connected=true — shows a react-hot-toast success toast "Google Calendar connected" and removes the query param from the
  URL using window.history.replaceState.
  - On return with ?error=access_denied — shows an inline error banner and clears the query param.
  - Connected state — displays a green checkmark badge and a "Disconnect" button.
  - "Disconnect" calls DELETE /api/v1/calendar/google/disconnect and parses response.data.status === 'success' (non-standard field, not
  response.data.success).
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #360 — Presence Heartbeat: REST Fallback for Non-WebSocket Clients
  
  Files changed:
  
  - src/services/presence.service.ts (rewritten)
  - src/hooks/usePresenceHeartbeat.ts (new)
  - src/layouts/DashboardLayout.tsx (updated)
  
  What was implemented:
  
  The backend's Redis presence key has a 30-second TTL. The WebSocket pong handler keeps presence alive when connected, but a REST fallback
  is required when WebSocket is unavailable.
  
  - sendHeartbeat — POST /presence/heartbeat returns 204 No Content. The response body is not parsed.
  - getUserOnlineStatus — GET /users/:id/online returns { online: boolean, last_seen: string | null } as a flat object (no .data wrapper).
  Parsed as response.data directly.
  - getBatchStatus — changed from GET /presence/batch to POST /users/online-status with { userIds } body. Returns { statuses: [...] } as a
  flat object (no .data wrapper). Parsed as response.data.statuses.
  - usePresenceHeartbeat hook — listens to ws-status CustomEvents dispatched by useWebSocket:
    - When WebSocket disconnects → starts setInterval sending POST /presence/heartbeat every 20 seconds.
    - When WebSocket reconnects → clears the interval immediately.
    - Cleans up the interval on unmount.
  
  - The hook is called inside DashboardLayout so it is active for all authenticated pages.
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Testing Notes
  
  - Export flow can be tested by triggering an export and observing the polling states (pending → processing → completed/failed).
  - Calendar OAuth flow requires a backend with Google OAuth configured; the ?connected=true and ?error=access_denied query param handling
  can be tested by navigating to /settings/calendar?connected=true directly.
  - Presence heartbeat fallback activates automatically when the WebSocket connection drops; verify via network tab that POST
  /presence/heartbeat fires every 20s only when WS is disconnected.