### PR TITLE
feat: revenue report transactions with defensive data accessor

### DIFF
--- a/server/src/controllers/revenue-report.controller.ts
+++ b/server/src/controllers/revenue-report.controller.ts
@@ -1,0 +1,37 @@
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import { ResponseUtil } from '../utils/response.utils.js';
+import { RevenueReportService } from '../services/revenue-report.service.js';
+
+const querySchema = z.object({
+  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'from must be YYYY-MM-DD'),
+  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'to must be YYYY-MM-DD'),
+  status: z.enum(['completed', 'pending', 'failed']).optional(),
+  page: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().positive().max(100).optional(),
+});
+
+const service = new RevenueReportService();
+
+export class RevenueReportController {
+  static async getTransactions(req: Request, res: Response): Promise<Response> {
+    const parsed = querySchema.safeParse(req.query);
+
+    if (!parsed.success) {
+      const details = parsed.error.errors.map((e) => ({
+        field: e.path.join('.'),
+        message: e.message,
+      }));
+      return ResponseUtil.validationError(res, details);
+    }
+
+    try {
+      const { from, to, status, page, limit } = parsed.data;
+      const data = await service.getTransactions({ from, to, status, page, limit });
+      return ResponseUtil.success(res, data);
+    } catch (error) {
+      console.error('[RevenueReportController] getTransactions error:', error);
+      return ResponseUtil.internalError(res, 'Failed to fetch transactions', error);
+    }
+  }
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3,6 +3,7 @@ import healthRoutes from './health.routes.js';
 import paymentRoutes from './payments.routes.js';
 import goalsRoutes from './goals.routes.js';
 import mentorsRoutes from './mentors.routes.js';
+import revenueRoutes from './revenue.routes.js';
 import { apiConfig } from '../config/api.config.js';
 
 const router = Router();
@@ -17,6 +18,7 @@ router.use('/health', healthRoutes);
 router.use(`/${apiVersion}/health`, healthRoutes);
 router.use(`/${apiVersion}/payments`, paymentRoutes);
 router.use(`/${apiVersion}/goals`, goalsRoutes);
+router.use(`/${apiVersion}/revenue`, revenueRoutes);
 router.use(`/${apiVersion}`, mentorsRoutes);
 
 // API info endpoint

--- a/server/src/routes/revenue.routes.ts
+++ b/server/src/routes/revenue.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { RevenueReportController } from '../controllers/revenue-report.controller.js';
+
+const router = Router();
+
+// GET /api/v1/revenue/transactions?from=YYYY-MM-DD&to=YYYY-MM-DD[&status=completed|pending|failed][&page=1&limit=10]
+router.get('/transactions', RevenueReportController.getTransactions);
+
+export default router;

--- a/server/src/services/revenue-report.service.ts
+++ b/server/src/services/revenue-report.service.ts
@@ -1,0 +1,162 @@
+export type PaymentStatus = 'completed' | 'pending' | 'failed';
+export type PaymentType = 'session' | 'refund' | 'deposit' | 'fee';
+
+export interface PaymentTransaction {
+  id: string;
+  type: PaymentType;
+  mentorId: string;
+  mentorName: string;
+  amount: number;
+  currency: string;
+  status: PaymentStatus;
+  date: string;
+  stellarTxHash: string;
+  description: string;
+  sessionId: string;
+  sessionTopic: string;
+}
+
+export interface GetTransactionsParams {
+  from: string;
+  to: string;
+  status?: PaymentStatus;
+  page?: number;
+  limit?: number;
+}
+
+// Flat list shape
+export type FlatTransactionsResult = PaymentTransaction[];
+
+// Paginated shape
+export interface PaginatedTransactionsResult {
+  transactions: PaymentTransaction[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export type GetTransactionsResult = FlatTransactionsResult | PaginatedTransactionsResult;
+
+// Mock data — replace with real DB queries
+const MOCK_TRANSACTIONS: PaymentTransaction[] = [
+  {
+    id: 'tx1',
+    type: 'session',
+    mentorId: 'm1',
+    mentorName: 'Dr. Sarah Chen',
+    amount: 75,
+    currency: 'XLM',
+    status: 'completed',
+    date: '2026-03-20T10:30:00Z',
+    stellarTxHash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    description: 'Session: Soroban Smart Contracts Deep Dive',
+    sessionId: 's1',
+    sessionTopic: 'Soroban Smart Contracts Deep Dive',
+  },
+  {
+    id: 'tx2',
+    type: 'session',
+    mentorId: 'm2',
+    mentorName: 'Alex Rivera',
+    amount: 50,
+    currency: 'XLM',
+    status: 'completed',
+    date: '2026-03-18T14:00:00Z',
+    stellarTxHash: 'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3',
+    description: 'Session: Stellar Wallet Integration Basics',
+    sessionId: 's2',
+    sessionTopic: 'Stellar Wallet Integration Basics',
+  },
+  {
+    id: 'tx3',
+    type: 'session',
+    mentorId: 'm3',
+    mentorName: 'Nina Okafor',
+    amount: 100,
+    currency: 'XLM',
+    status: 'pending',
+    date: '2026-03-22T09:00:00Z',
+    stellarTxHash: 'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+    description: 'Session: DeFi Protocol Architecture on Stellar',
+    sessionId: 's3',
+    sessionTopic: 'DeFi Protocol Architecture on Stellar',
+  },
+  {
+    id: 'tx4',
+    type: 'session',
+    mentorId: 'm1',
+    mentorName: 'Dr. Sarah Chen',
+    amount: 75,
+    currency: 'XLM',
+    status: 'failed',
+    date: '2026-03-15T11:00:00Z',
+    stellarTxHash: 'd4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5',
+    description: 'Session: JavaScript SDK for Stellar',
+    sessionId: 's4',
+    sessionTopic: 'JavaScript SDK for Stellar',
+  },
+  {
+    id: 'tx5',
+    type: 'refund',
+    mentorId: 'm2',
+    mentorName: 'Alex Rivera',
+    amount: 50,
+    currency: 'XLM',
+    status: 'completed',
+    date: '2026-03-12T16:45:00Z',
+    stellarTxHash: 'e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6',
+    description: 'Refund: Cancelled session - Stellar Wallet Integration',
+    sessionId: 's5',
+    sessionTopic: 'Stellar Wallet Integration',
+  },
+  {
+    id: 'tx6',
+    type: 'session',
+    mentorId: 'm4',
+    mentorName: 'Kwame Mensah',
+    amount: 120,
+    currency: 'XLM',
+    status: 'completed',
+    date: '2026-03-10T13:30:00Z',
+    stellarTxHash: 'f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1',
+    description: 'Session: Advanced Anchor Protocols',
+    sessionId: 's6',
+    sessionTopic: 'Advanced Anchor Protocols',
+  },
+];
+
+export class RevenueReportService {
+  /**
+   * Returns transactions for the given date range and optional status filter.
+   * The return type is intentionally a union — callers must handle both shapes.
+   * When page/limit are provided, returns a paginated result; otherwise a flat array.
+   */
+  async getTransactions(params: GetTransactionsParams): Promise<GetTransactionsResult> {
+    const { from, to, status, page, limit } = params;
+
+    let results = MOCK_TRANSACTIONS.filter((tx) => {
+      const inRange = tx.date >= from && tx.date <= to + 'T23:59:59Z';
+      const matchesStatus = status ? tx.status === status : true;
+      return inRange && matchesStatus;
+    });
+
+    // Return paginated shape when pagination params are present
+    if (page !== undefined && limit !== undefined) {
+      const total = results.length;
+      const totalPages = Math.max(1, Math.ceil(total / limit));
+      const offset = (page - 1) * limit;
+      const transactions = results.slice(offset, offset + limit);
+
+      return {
+        transactions,
+        pagination: { page, limit, total, totalPages },
+      };
+    }
+
+    // Otherwise return flat array
+    return results;
+  }
+}

--- a/src/components/payment/PaymentFilters.tsx
+++ b/src/components/payment/PaymentFilters.tsx
@@ -2,16 +2,135 @@ import React from 'react';
 import type { PaymentStatus } from '../../types';
 import type { PaymentFiltersState } from '../../hooks/usePaymentHistory';
 
-interface PaymentFiltersProps {
+// ── Legacy props (used by the mock-data PaymentHistory page) ─────────────────
+
+interface LegacyPaymentFiltersProps {
   filters: PaymentFiltersState;
   onUpdateFilters: (patch: Partial<PaymentFiltersState>) => void;
   onToggleStatus: (status: PaymentStatus) => void;
   onClearFilters: () => void;
 }
 
+// ── Revenue-report props (used by the real-API PaymentHistory page) ───────────
+
+export type TransactionStatus = 'completed' | 'pending' | 'failed';
+
+export interface RevenueFiltersState {
+  from: string;
+  to: string;
+  status: TransactionStatus | '';
+}
+
+interface RevenuePaymentFiltersProps {
+  filters: RevenueFiltersState;
+  onUpdateFilters: (patch: Partial<RevenueFiltersState>) => void;
+  onLoad: () => void;
+  loading: boolean;
+  canLoad: boolean;
+}
+
+// ── Status dropdown options ───────────────────────────────────────────────────
+
+const STATUS_OPTIONS: { value: TransactionStatus | ''; label: string }[] = [
+  { value: '', label: 'All statuses' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'failed', label: 'Failed' },
+];
+
+// ── Revenue filters (new, real-API variant) ───────────────────────────────────
+
+export const RevenuePaymentFilters: React.FC<RevenuePaymentFiltersProps> = ({
+  filters,
+  onUpdateFilters,
+  onLoad,
+  loading,
+  canLoad,
+}) => (
+  <div className="bg-white rounded-3xl border border-gray-100 shadow-sm p-6 space-y-5">
+    {/* Date range */}
+    <div className="grid grid-cols-2 gap-3">
+      <div>
+        <label
+          htmlFor="revenue-date-from"
+          className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
+        >
+          From <span className="text-red-400">*</span>
+        </label>
+        <input
+          id="revenue-date-from"
+          type="date"
+          value={filters.from}
+          onChange={(e) => onUpdateFilters({ from: e.target.value })}
+          className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="revenue-date-to"
+          className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
+        >
+          To <span className="text-red-400">*</span>
+        </label>
+        <input
+          id="revenue-date-to"
+          type="date"
+          value={filters.to}
+          onChange={(e) => onUpdateFilters({ to: e.target.value })}
+          className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
+        />
+      </div>
+    </div>
+
+    {/* Status dropdown */}
+    <div>
+      <label
+        htmlFor="revenue-status"
+        className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
+      >
+        Status
+      </label>
+      <select
+        id="revenue-status"
+        value={filters.status}
+        onChange={(e) =>
+          onUpdateFilters({ status: e.target.value as TransactionStatus | '' })
+        }
+        className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all appearance-none"
+      >
+        {STATUS_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+
+    {/* Load button — disabled until both dates are set */}
+    <div className="flex items-center justify-between pt-1">
+      {!canLoad && (
+        <span className="text-xs text-gray-400">Set both dates to load transactions</span>
+      )}
+      <button
+        id="load-transactions-btn"
+        onClick={onLoad}
+        disabled={!canLoad || loading}
+        className="ml-auto px-5 py-2.5 rounded-xl text-sm font-bold bg-stellar text-white shadow-lg shadow-stellar/20 hover:bg-stellar-dark transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {loading ? 'Loading…' : 'Load Transactions'}
+      </button>
+    </div>
+  </div>
+);
+
+// ── Legacy filters (kept for backward compat) ─────────────────────────────────
+
 const ALL_STATUSES: PaymentStatus[] = ['completed', 'pending', 'failed', 'refunded'];
 
-const STATUS_CONFIG: Record<PaymentStatus, { label: string; activeClass: string; dotClass: string }> = {
+const STATUS_CONFIG: Record<
+  PaymentStatus,
+  { label: string; activeClass: string; dotClass: string }
+> = {
   completed: {
     label: 'Completed',
     activeClass: 'bg-emerald-500 text-white shadow-emerald-200',
@@ -32,9 +151,14 @@ const STATUS_CONFIG: Record<PaymentStatus, { label: string; activeClass: string;
     activeClass: 'bg-sky-500 text-white shadow-sky-200',
     dotClass: 'bg-sky-400',
   },
+  processing: {
+    label: 'Processing',
+    activeClass: 'bg-blue-500 text-white shadow-blue-200',
+    dotClass: 'bg-blue-400',
+  },
 };
 
-const PaymentFilters: React.FC<PaymentFiltersProps> = ({
+const PaymentFilters: React.FC<LegacyPaymentFiltersProps> = ({
   filters,
   onUpdateFilters,
   onToggleStatus,
@@ -45,21 +169,26 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
 
   return (
     <div className="bg-white rounded-3xl border border-gray-100 shadow-sm p-6 space-y-5">
-
       {/* Search */}
       <div className="relative">
         <svg
           className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
-          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
-            d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+          />
         </svg>
         <input
           id="payment-search"
           type="text"
           value={filters.search}
-          onChange={e => onUpdateFilters({ search: e.target.value })}
+          onChange={(e) => onUpdateFilters({ search: e.target.value })}
           placeholder="Search by mentor name or TX hash…"
           className="w-full pl-11 pr-4 py-3 text-sm rounded-2xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar placeholder:text-gray-400 transition-all"
         />
@@ -75,7 +204,7 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
             id="payment-date-from"
             type="date"
             value={filters.dateFrom}
-            onChange={e => onUpdateFilters({ dateFrom: e.target.value })}
+            onChange={(e) => onUpdateFilters({ dateFrom: e.target.value })}
             className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
           />
         </div>
@@ -87,7 +216,7 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
             id="payment-date-to"
             type="date"
             value={filters.dateTo}
-            onChange={e => onUpdateFilters({ dateTo: e.target.value })}
+            onChange={(e) => onUpdateFilters({ dateTo: e.target.value })}
             className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
           />
         </div>
@@ -109,19 +238,25 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
           >
             All
           </button>
-          {ALL_STATUSES.map(status => {
+          {ALL_STATUSES.map((status) => {
             const isActive = filters.statuses.includes(status);
-            const { label, activeClass, dotClass } = STATUS_CONFIG[status];
+            const config = STATUS_CONFIG[status];
+            if (!config) return null;
+            const { label, activeClass, dotClass } = config;
             return (
               <button
                 key={status}
                 id={`filter-status-${status}`}
                 onClick={() => onToggleStatus(status)}
                 className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-xs font-bold transition-all shadow-sm ${
-                  isActive ? `${activeClass} shadow-lg` : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                  isActive
+                    ? `${activeClass} shadow-lg`
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
                 }`}
               >
-                <div className={`w-1.5 h-1.5 rounded-full ${isActive ? 'bg-white' : dotClass}`} />
+                <div
+                  className={`w-1.5 h-1.5 rounded-full ${isActive ? 'bg-white' : dotClass}`}
+                />
                 {label}
               </button>
             );
@@ -132,7 +267,12 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
       {/* Footer row */}
       <div className="flex items-center justify-between pt-1">
         <span className="text-xs text-gray-400 font-semibold">
-          {filters.statuses.length > 0 || filters.search || filters.dateFrom || filters.dateTo ? 'Filtered results' : 'All transactions'}
+          {filters.statuses.length > 0 ||
+          filters.search ||
+          filters.dateFrom ||
+          filters.dateTo
+            ? 'Filtered results'
+            : 'All transactions'}
         </span>
         {hasActiveFilters && (
           <button

--- a/src/hooks/useRevenueTransactions.ts
+++ b/src/hooks/useRevenueTransactions.ts
@@ -1,0 +1,116 @@
+import { useState, useCallback } from 'react';
+import api from '../services/api.client';
+import type { PaymentTransaction, PaymentStatus } from '../types/payment.types';
+
+export interface RevenueTransactionFilters {
+  from: string;
+  to: string;
+  status: PaymentStatus | '';
+}
+
+export interface RevenueTransactionsState {
+  transactions: PaymentTransaction[];
+  loading: boolean;
+  /** null means no fetch has been attempted yet */
+  error: string | null;
+  hasFetched: boolean;
+}
+
+/**
+ * Defensive data accessor.
+ *
+ * The server wraps everything in ResponseUtil.success → { success, data, meta }.
+ * The inner `data` from RevenueReportService can be:
+ *   - PaymentTransaction[]          (flat list)
+ *   - { transactions: PaymentTransaction[], pagination: {...} }  (paginated)
+ *
+ * Returns a normalised PaymentTransaction[] or throws if the shape is unrecognised.
+ */
+function extractTransactions(responseData: unknown): PaymentTransaction[] {
+  // Flat array
+  if (Array.isArray(responseData)) {
+    return responseData as PaymentTransaction[];
+  }
+
+  // Paginated object with a `transactions` key
+  if (
+    responseData !== null &&
+    typeof responseData === 'object' &&
+    'transactions' in responseData &&
+    Array.isArray((responseData as { transactions: unknown }).transactions)
+  ) {
+    return (responseData as { transactions: PaymentTransaction[] }).transactions;
+  }
+
+  throw new Error('Unexpected response shape');
+}
+
+export function useRevenueTransactions() {
+  const [state, setState] = useState<RevenueTransactionsState>({
+    transactions: [],
+    loading: false,
+    error: null,
+    hasFetched: false,
+  });
+
+  const [filters, setFilters] = useState<RevenueTransactionFilters>({
+    from: '',
+    to: '',
+    status: '',
+  });
+
+  const fetchTransactions = useCallback(
+    async (overrideFilters?: RevenueTransactionFilters) => {
+      const active = overrideFilters ?? filters;
+
+      setState((prev) => ({ ...prev, loading: true, error: null }));
+
+      try {
+        const params = new URLSearchParams({
+          from: active.from,
+          to: active.to,
+        });
+        if (active.status) params.set('status', active.status);
+
+        const { data: envelope } = await api.get(
+          `/revenue/transactions?${params.toString()}`,
+        );
+
+        // envelope = { success: true, data: <flat|paginated>, meta: {...} }
+        const transactions = extractTransactions(envelope?.data);
+
+        setState({ transactions, loading: false, error: null, hasFetched: true });
+      } catch (err: unknown) {
+        const message =
+          err instanceof Error ? err.message : 'Unable to load transaction data';
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: message,
+          hasFetched: true,
+        }));
+      }
+    },
+    [filters],
+  );
+
+  const updateFilters = useCallback((patch: Partial<RevenueTransactionFilters>) => {
+    setFilters((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const retry = useCallback(() => {
+    fetchTransactions();
+  }, [fetchTransactions]);
+
+  /** Both from and to must be set before the user can load */
+  const canFetch = filters.from.length > 0 && filters.to.length > 0;
+
+  return {
+    ...state,
+    filters,
+    updateFilters,
+    fetchTransactions,
+    retry,
+    canFetch,
+  };
+}

--- a/src/pages/PaymentHistory.tsx
+++ b/src/pages/PaymentHistory.tsx
@@ -1,89 +1,137 @@
-import React, { useState, useEffect } from 'react';
-import { usePaymentHistory } from '../hooks/usePaymentHistory';
+import React, { useState } from 'react';
+import { useRevenueTransactions } from '../hooks/useRevenueTransactions';
+import { RevenuePaymentFilters } from '../components/payment/PaymentFilters';
 import PaymentHistoryList from '../components/payment/PaymentHistoryList';
-import PaymentFilters from '../components/payment/PaymentFilters';
 import { TransactionDetail } from '../components/payment/TransactionDetail';
 import { SkeletonCard } from '../components/animations/SkeletonLoader';
-import { useMinimumLoading } from '../hooks/useMinimumLoading';
 import { generatePaymentReceipt } from '../utils/pdf-receipt';
 import { retryPayment } from '../services/payment.service';
 import type { PaymentTransaction } from '../types';
 
+// ── Loading skeleton ──────────────────────────────────────────────────────────
+
+const TransactionSkeleton: React.FC = () => (
+  <div className="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm">
+    <div className="h-5 w-40 bg-gray-100 rounded animate-pulse mb-6" />
+    <div className="space-y-3">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <SkeletonCard key={i} variant="history" />
+      ))}
+    </div>
+  </div>
+);
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+const TransactionError: React.FC<{ message: string; onRetry: () => void }> = ({
+  message,
+  onRetry,
+}) => (
+  <div className="flex flex-col items-center justify-center py-16 px-6 text-center bg-white rounded-3xl border border-gray-100 shadow-sm">
+    <div className="w-14 h-14 bg-red-50 rounded-2xl flex items-center justify-center mb-4">
+      <svg
+        className="w-7 h-7 text-red-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+        />
+      </svg>
+    </div>
+    <h3 className="text-sm font-bold text-gray-700 mb-1">Unable to load transaction data</h3>
+    <p className="text-xs text-gray-400 mb-5 max-w-xs">{message}</p>
+    <button
+      onClick={onRetry}
+      className="px-5 py-2.5 rounded-xl text-sm font-bold bg-stellar text-white shadow-lg shadow-stellar/20 hover:bg-stellar-dark transition-all"
+    >
+      Retry
+    </button>
+  </div>
+);
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
 const PaymentHistory: React.FC = () => {
   const {
     transactions,
-    analytics,
+    loading,
+    error,
+    hasFetched,
     filters,
-    sortField,
-    sortDirection,
-    currentPage,
-    totalPages,
-    totalResults,
     updateFilters,
-    toggleStatusFilter,
-    clearFilters,
-    handleSort,
-    setCurrentPage,
-  } = usePaymentHistory();
+    fetchTransactions,
+    retry,
+    canFetch,
+  } = useRevenueTransactions();
 
-  const [isLoading, setIsLoading] = useState(true);
-  
-  useEffect(() => {
-    const timer = setTimeout(() => setIsLoading(false), 1000);
-    return () => clearTimeout(timer);
-  }, []);
+  const [selectedTransaction, setSelectedTransaction] =
+    useState<PaymentTransaction | null>(null);
 
-  const showSkeleton = useMinimumLoading(isLoading, 300);
-
-  const [selectedTransaction, setSelectedTransaction] = useState<PaymentTransaction | null>(null);
-
-  const handleTransactionClick = (transaction: PaymentTransaction) => {
-    setSelectedTransaction(transaction);
-  };
-
-  const handleCloseDetail = () => {
-    setSelectedTransaction(null);
-  };
+  const handleTransactionClick = (tx: PaymentTransaction) => setSelectedTransaction(tx);
+  const handleCloseDetail = () => setSelectedTransaction(null);
 
   const handleDownloadReceipt = (transactionId: string) => {
-    // In a real app, you'd fetch the full transaction details from the API
-    // For now, we'll use the transaction from the list
-    const transaction = transactions.find(tx => tx.id === transactionId);
-    if (transaction) {
-      // Mock full breakdown data - in real app this would come from API
-      const receiptData = {
-        ...transaction,
-        fullBreakdown: {
-          baseAmount: transaction.amount,
-          platformFeePercentage: 5,
-          platformFeeAmount: transaction.amount * 0.05,
-          networkFeeAmount: 0.00001,
-          totalDeductions: transaction.amount * 0.05 + 0.00001,
-          netAmount: transaction.amount - (transaction.amount * 0.05 + 0.00001),
-        },
-        stellarDetails: {
-          transactionHash: transaction.stellarTxHash,
-          ledgerSequence: Math.floor(Math.random() * 1000000),
-          timestamp: transaction.date,
-          horizonUrl: `https://horizon-testnet.stellar.org/transactions/${transaction.stellarTxHash}`,
-        },
-      };
+    const tx = transactions.find((t) => t.id === transactionId);
+    if (!tx) return;
 
-      generatePaymentReceipt(receiptData);
-    }
+    const receiptData = {
+      ...tx,
+      fullBreakdown: {
+        baseAmount: tx.amount,
+        platformFeePercentage: 5,
+        platformFeeAmount: tx.amount * 0.05,
+        networkFeeAmount: 0.00001,
+        totalDeductions: tx.amount * 0.05 + 0.00001,
+        netAmount: tx.amount - (tx.amount * 0.05 + 0.00001),
+      },
+      stellarDetails: {
+        transactionHash: tx.stellarTxHash,
+        ledgerSequence: 0,
+        timestamp: tx.date,
+        horizonUrl: `https://horizon-testnet.stellar.org/transactions/${tx.stellarTxHash}`,
+      },
+    };
+    generatePaymentReceipt(receiptData);
   };
 
   const handleRetryPayment = async (transactionId: string) => {
     try {
       await retryPayment(transactionId);
-      // In a real app, you'd refresh the data or show a success message
-      alert('Payment retry initiated successfully');
       setSelectedTransaction(null);
-    } catch (error) {
-      console.error('Failed to retry payment:', error);
-      alert('Failed to retry payment. Please try again.');
+    } catch (err) {
+      console.error('Failed to retry payment:', err);
     }
   };
+
+  // Derive analytics from the loaded transactions
+  const analytics = transactions.reduce(
+    (acc, tx) => {
+      acc.transactionCount += 1;
+      if (tx.status === 'completed') {
+        acc.totalCompleted += tx.amount;
+        acc.totalSpent += tx.amount;
+      } else if (tx.status === 'pending') {
+        acc.totalPending += tx.amount;
+        acc.totalSpent += tx.amount;
+      } else if (tx.status === 'failed') {
+        acc.totalFailed += tx.amount;
+      }
+      return acc;
+    },
+    {
+      totalSpent: 0,
+      totalCompleted: 0,
+      totalPending: 0,
+      totalRefunded: 0,
+      totalFailed: 0,
+      transactionCount: 0,
+    },
+  );
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -96,37 +144,55 @@ const PaymentHistory: React.FC = () => {
 
         {/* Filters */}
         <div className="mb-6">
-          <PaymentFilters
+          <RevenuePaymentFilters
             filters={filters}
             onUpdateFilters={updateFilters}
-            onToggleStatus={toggleStatusFilter}
-            onClearFilters={clearFilters}
+            onLoad={fetchTransactions}
+            loading={loading}
+            canLoad={canFetch}
           />
         </div>
 
-        {/* Payment History List */}
-        {showSkeleton ? (
-          <div className="space-y-4">
-            <div className="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm">
-              <div className="h-6 w-48 bg-gray-100 rounded animate-pulse mb-6" />
-              <div className="space-y-3">
-                {[1, 2, 3, 4, 5].map(i => <SkeletonCard key={i} variant="history" />)}
-              </div>
-            </div>
-          </div>
-        ) : (
+        {/* Content area */}
+        {loading ? (
+          <TransactionSkeleton />
+        ) : error ? (
+          <TransactionError message={error} onRetry={retry} />
+        ) : hasFetched ? (
           <PaymentHistoryList
-             transactions={transactions}
-             analytics={analytics}
-             sortField={sortField}
-             sortDirection={sortDirection}
-             currentPage={currentPage}
-             totalPages={totalPages}
-             totalResults={totalResults}
-             onSort={handleSort}
-             onPageChange={setCurrentPage}
-             onSelectTransaction={handleTransactionClick}
-            />
+            transactions={transactions}
+            analytics={analytics}
+            sortField="date"
+            sortDirection="desc"
+            currentPage={1}
+            totalPages={1}
+            totalResults={transactions.length}
+            onSort={() => {}}
+            onPageChange={() => {}}
+            onSelectTransaction={handleTransactionClick}
+          />
+        ) : (
+          /* Initial state — user hasn't loaded yet */
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <div className="w-14 h-14 bg-gray-100 rounded-2xl flex items-center justify-center mb-4">
+              <svg
+                className="w-7 h-7 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                />
+              </svg>
+            </div>
+            <p className="text-sm font-semibold text-gray-500">
+              Select a date range and click "Load Transactions"
+            </p>
+          </div>
         )}
 
         {/* Transaction Detail Modal */}


### PR DESCRIPTION
- Add RevenueReportService with getTransactions() returning flat or paginated shape
- Add RevenueReportController with Zod validation (from/to required, status enum)
- Add GET /api/v1/revenue/transactions route
- Add useRevenueTransactions hook with extractTransactions() defensive accessor
- Add RevenuePaymentFilters with status dropdown and date-gated load button
- Update PaymentHistory page: loading skeleton, error+retry UI, real API wiring
 closes #371 