### PR TITLE
Feat/iso8601 date range validation

### DIFF
--- a/server/src/controllers/export.controller.ts
+++ b/server/src/controllers/export.controller.ts
@@ -1,0 +1,95 @@
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import { ResponseUtil } from '../utils/response.utils.js';
+import { ExportService } from '../services/export.service.js';
+
+const jobIdSchema = z.object({
+  jobId: z.string().min(1, 'jobId is required'),
+});
+
+const service = new ExportService();
+
+export class ExportController {
+  /**
+   * POST /export
+   * Creates a new export job and returns the jobId immediately.
+   */
+  static createJob(req: Request, res: Response): Response {
+    try {
+      const job = service.createJob();
+      return ResponseUtil.created(res, {
+        jobId: job.jobId,
+        status: job.status,
+        createdAt: job.createdAt,
+      });
+    } catch (error) {
+      console.error('[ExportController] createJob error:', error);
+      return ResponseUtil.internalError(res, 'Failed to create export job', error as Error);
+    }
+  }
+
+  /**
+   * GET /export/:jobId/status
+   * Returns the current status of an export job.
+   * Status is one of: pending | processing | completed | failed
+   */
+  static getExportStatus(req: Request, res: Response): Response {
+    const parsed = jobIdSchema.safeParse(req.params);
+    if (!parsed.success) {
+      return ResponseUtil.badRequest(res, 'Invalid jobId');
+    }
+
+    const job = service.getJob(parsed.data.jobId);
+    if (!job) {
+      return ResponseUtil.notFound(res, 'Export job not found');
+    }
+
+    return ResponseUtil.success(res, {
+      jobId: job.jobId,
+      status: job.status,
+      createdAt: job.createdAt,
+      expiresAt: job.expiresAt,
+      // Only expose error_message when failed — matches the AC exactly
+      ...(job.status === 'failed' && { error_message: job.error_message }),
+    });
+  }
+
+  /**
+   * GET /export/:jobId/download
+   * Streams (or redirects to) the export file.
+   * Returns 410 Gone if the download has expired.
+   */
+  static getDownload(req: Request, res: Response): Response {
+    const parsed = jobIdSchema.safeParse(req.params);
+    if (!parsed.success) {
+      return ResponseUtil.badRequest(res, 'Invalid jobId');
+    }
+
+    const result = service.getDownload(parsed.data.jobId);
+
+    if (result === null) {
+      return ResponseUtil.notFound(res, 'Export job not found or not yet completed');
+    }
+
+    if ('expired' in result) {
+      // 410 Gone — the resource existed but is no longer available
+      return res.status(410).json({
+        success: false,
+        error: {
+          code: 'DOWNLOAD_EXPIRED',
+          message: 'This download has expired. Please request a new export.',
+        },
+      });
+    }
+
+    // In production: stream the file or redirect to a signed S3 URL.
+    // Here we return a minimal CSV payload to demonstrate the flow.
+    const csv = 'id,status,date\ntx1,completed,2026-03-20\ntx2,pending,2026-03-22\n';
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="export_${result.job.jobId}.csv"`,
+    );
+    return res.status(200).send(csv);
+  }
+}

--- a/server/src/controllers/revenue-report.controller.ts
+++ b/server/src/controllers/revenue-report.controller.ts
@@ -3,13 +3,30 @@ import { z } from 'zod';
 import { ResponseUtil } from '../utils/response.utils.js';
 import { RevenueReportService } from '../services/revenue-report.service.js';
 
-const querySchema = z.object({
-  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'from must be YYYY-MM-DD'),
-  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'to must be YYYY-MM-DD'),
-  status: z.enum(['completed', 'pending', 'failed']).optional(),
-  page: z.coerce.number().int().positive().optional(),
-  limit: z.coerce.number().int().positive().max(100).optional(),
-});
+/**
+ * Accept full ISO 8601 timestamps.
+ * The frontend sends:
+ *   from = "2025-01-01T00:00:00.000Z"  (start of day UTC)
+ *   to   = "2025-01-31T23:59:59.999Z"  (end of day UTC)
+ */
+const ISO_8601_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+const querySchema = z
+  .object({
+    from: z
+      .string()
+      .regex(ISO_8601_RE, 'from must be a full ISO 8601 UTC timestamp (e.g. 2025-01-01T00:00:00.000Z)'),
+    to: z
+      .string()
+      .regex(ISO_8601_RE, 'to must be a full ISO 8601 UTC timestamp (e.g. 2025-01-31T23:59:59.999Z)'),
+    status: z.enum(['completed', 'pending', 'failed']).optional(),
+    page: z.coerce.number().int().positive().optional(),
+    limit: z.coerce.number().int().positive().max(100).optional(),
+  })
+  .refine((d) => new Date(d.from) < new Date(d.to), {
+    message: 'Start date must be before end date',
+    path: ['from'],
+  });
 
 const service = new RevenueReportService();
 
@@ -18,11 +35,19 @@ export class RevenueReportController {
     const parsed = querySchema.safeParse(req.query);
 
     if (!parsed.success) {
-      const details = parsed.error.errors.map((e) => ({
-        field: e.path.join('.'),
-        message: e.message,
-      }));
-      return ResponseUtil.validationError(res, details);
+      // Return the first human-readable message so the frontend can show it inline.
+      const firstError = parsed.error.errors[0];
+      return res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: firstError.message,
+          details: parsed.error.errors.map((e) => ({
+            field: e.path.join('.'),
+            message: e.message,
+          })),
+        },
+      });
     }
 
     try {
@@ -31,7 +56,7 @@ export class RevenueReportController {
       return ResponseUtil.success(res, data);
     } catch (error) {
       console.error('[RevenueReportController] getTransactions error:', error);
-      return ResponseUtil.internalError(res, 'Failed to fetch transactions', error);
+      return ResponseUtil.internalError(res, 'Failed to fetch transactions', error as Error);
     }
   }
 }

--- a/server/src/controllers/revenue-report.controller.ts
+++ b/server/src/controllers/revenue-report.controller.ts
@@ -1,0 +1,37 @@
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import { ResponseUtil } from '../utils/response.utils.js';
+import { RevenueReportService } from '../services/revenue-report.service.js';
+
+const querySchema = z.object({
+  from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'from must be YYYY-MM-DD'),
+  to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'to must be YYYY-MM-DD'),
+  status: z.enum(['completed', 'pending', 'failed']).optional(),
+  page: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().positive().max(100).optional(),
+});
+
+const service = new RevenueReportService();
+
+export class RevenueReportController {
+  static async getTransactions(req: Request, res: Response): Promise<Response> {
+    const parsed = querySchema.safeParse(req.query);
+
+    if (!parsed.success) {
+      const details = parsed.error.errors.map((e) => ({
+        field: e.path.join('.'),
+        message: e.message,
+      }));
+      return ResponseUtil.validationError(res, details);
+    }
+
+    try {
+      const { from, to, status, page, limit } = parsed.data;
+      const data = await service.getTransactions({ from, to, status, page, limit });
+      return ResponseUtil.success(res, data);
+    } catch (error) {
+      console.error('[RevenueReportController] getTransactions error:', error);
+      return ResponseUtil.internalError(res, 'Failed to fetch transactions', error);
+    }
+  }
+}

--- a/server/src/routes/export.routes.ts
+++ b/server/src/routes/export.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { ExportController } from '../controllers/export.controller.js';
+
+const router = Router();
+
+// POST   /api/v1/export              — create a new export job
+router.post('/', ExportController.createJob);
+
+// GET    /api/v1/export/:jobId/status   — poll job status
+router.get('/:jobId/status', ExportController.getExportStatus);
+
+// GET    /api/v1/export/:jobId/download — download completed export (410 if expired)
+router.get('/:jobId/download', ExportController.getDownload);
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3,6 +3,7 @@ import healthRoutes from './health.routes.js';
 import paymentRoutes from './payments.routes.js';
 import goalsRoutes from './goals.routes.js';
 import mentorsRoutes from './mentors.routes.js';
+import revenueRoutes from './revenue.routes.js';
 import { apiConfig } from '../config/api.config.js';
 
 const router = Router();
@@ -17,6 +18,7 @@ router.use('/health', healthRoutes);
 router.use(`/${apiVersion}/health`, healthRoutes);
 router.use(`/${apiVersion}/payments`, paymentRoutes);
 router.use(`/${apiVersion}/goals`, goalsRoutes);
+router.use(`/${apiVersion}/revenue`, revenueRoutes);
 router.use(`/${apiVersion}`, mentorsRoutes);
 
 // API info endpoint

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -4,6 +4,7 @@ import paymentRoutes from './payments.routes.js';
 import goalsRoutes from './goals.routes.js';
 import mentorsRoutes from './mentors.routes.js';
 import revenueRoutes from './revenue.routes.js';
+import exportRoutes from './export.routes.js';
 import { apiConfig } from '../config/api.config.js';
 
 const router = Router();
@@ -19,6 +20,7 @@ router.use(`/${apiVersion}/health`, healthRoutes);
 router.use(`/${apiVersion}/payments`, paymentRoutes);
 router.use(`/${apiVersion}/goals`, goalsRoutes);
 router.use(`/${apiVersion}/revenue`, revenueRoutes);
+router.use(`/${apiVersion}/export`, exportRoutes);
 router.use(`/${apiVersion}`, mentorsRoutes);
 
 // API info endpoint

--- a/server/src/routes/revenue.routes.ts
+++ b/server/src/routes/revenue.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { RevenueReportController } from '../controllers/revenue-report.controller.js';
+
+const router = Router();
+
+// GET /api/v1/revenue/transactions?from=YYYY-MM-DD&to=YYYY-MM-DD[&status=completed|pending|failed][&page=1&limit=10]
+router.get('/transactions', RevenueReportController.getTransactions);
+
+export default router;

--- a/server/src/services/export.service.ts
+++ b/server/src/services/export.service.ts
@@ -1,0 +1,109 @@
+/**
+ * ExportService — manages async export jobs.
+ *
+ * In production this would be backed by a database + a real queue worker.
+ * Here we use an in-memory Map and simulate processing with setTimeout.
+ */
+
+export type ExportJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+export interface ExportJob {
+  jobId: string;
+  status: ExportJobStatus;
+  /** ISO timestamp when the job was created */
+  createdAt: string;
+  /** ISO timestamp when the download URL expires (completed jobs only) */
+  expiresAt?: string;
+  /** Human-readable error when status === 'failed' */
+  error_message?: string;
+  /** Opaque download token — only present when status === 'completed' */
+  downloadToken?: string;
+}
+
+// TTL for completed jobs: 15 minutes
+const DOWNLOAD_TTL_MS = 15 * 60 * 1000;
+
+// Simulated processing time range (ms)
+const PROCESSING_DELAY_MS = 4000;
+
+const jobs = new Map<string, ExportJob>();
+
+function generateId(): string {
+  return `export_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export class ExportService {
+  /**
+   * Create a new export job and kick off async processing.
+   * Returns immediately with a jobId the client can poll.
+   */
+  createJob(): ExportJob {
+    const jobId = generateId();
+    const job: ExportJob = {
+      jobId,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+    };
+
+    jobs.set(jobId, job);
+
+    // Simulate async pipeline: pending → processing → completed|failed
+    setTimeout(() => {
+      const j = jobs.get(jobId);
+      if (!j) return;
+      j.status = 'processing';
+      jobs.set(jobId, { ...j });
+
+      setTimeout(() => {
+        const j2 = jobs.get(jobId);
+        if (!j2) return;
+
+        // Simulate ~10% failure rate for realism
+        const failed = Math.random() < 0.1;
+        if (failed) {
+          jobs.set(jobId, {
+            ...j2,
+            status: 'failed',
+            error_message: 'Export pipeline encountered an error. Please try again.',
+          });
+        } else {
+          const expiresAt = new Date(Date.now() + DOWNLOAD_TTL_MS).toISOString();
+          jobs.set(jobId, {
+            ...j2,
+            status: 'completed',
+            expiresAt,
+            downloadToken: generateId(),
+          });
+        }
+      }, PROCESSING_DELAY_MS);
+    }, 1500);
+
+    return job;
+  }
+
+  /**
+   * Returns the current job snapshot, or null if not found.
+   */
+  getJob(jobId: string): ExportJob | null {
+    return jobs.get(jobId) ?? null;
+  }
+
+  /**
+   * Validates that a completed job's download is still within its TTL.
+   * Returns the job if valid, null if not found, or throws 'EXPIRED' if past TTL.
+   */
+  getDownload(jobId: string): { job: ExportJob } | { expired: true } | null {
+    const job = jobs.get(jobId);
+    if (!job) return null;
+
+    if (job.status !== 'completed') {
+      return null;
+    }
+
+    if (job.expiresAt && new Date(job.expiresAt) < new Date()) {
+      return { expired: true };
+    }
+
+    return { job };
+  }
+}

--- a/server/src/services/revenue-report.service.ts
+++ b/server/src/services/revenue-report.service.ts
@@ -1,0 +1,162 @@
+export type PaymentStatus = 'completed' | 'pending' | 'failed';
+export type PaymentType = 'session' | 'refund' | 'deposit' | 'fee';
+
+export interface PaymentTransaction {
+  id: string;
+  type: PaymentType;
+  mentorId: string;
+  mentorName: string;
+  amount: number;
+  currency: string;
+  status: PaymentStatus;
+  date: string;
+  stellarTxHash: string;
+  description: string;
+  sessionId: string;
+  sessionTopic: string;
+}
+
+export interface GetTransactionsParams {
+  from: string;
+  to: string;
+  status?: PaymentStatus;
+  page?: number;
+  limit?: number;
+}
+
+// Flat list shape
+export type FlatTransactionsResult = PaymentTransaction[];
+
+// Paginated shape
+export interface PaginatedTransactionsResult {
+  transactions: PaymentTransaction[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export type GetTransactionsResult = FlatTransactionsResult | PaginatedTransactionsResult;
+
+// Mock data — replace with real DB queries
+const MOCK_TRANSACTIONS: PaymentTransaction[] = [
+  {
+    id: 'tx1',
+    type: 'session',
+    mentorId: 'm1',
+    mentorName: 'Dr. Sarah Chen',
+    amount: 75,
+    currency: 'XLM',
+    status: 'completed',
+    date: '2026-03-20T10:30:00Z',
+    stellarTxHash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    description: 'Session: Soroban Smart Contracts Deep Dive',
+    sessionId: 's1',
+    sessionTopic: 'Soroban Smart Contracts Deep Dive',
+  },
+  {
+    id: 'tx2',
+    type: 'session',
+    mentorId: 'm2',
+    mentorName: 'Alex Rivera',
+    amount: 50,
+    currency: 'XLM',
+    status: 'completed',
+    date: '2026-03-18T14:00:00Z',
+    stellarTxHash: 'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3',
+    description: 'Session: Stellar Wallet Integration Basics',
+    sessionId: 's2',
+    sessionTopic: 'Stellar Wallet Integration Basics',
+  },
+  {
+    id: 'tx3',
+    type: 'session',
+    mentorId: 'm3',
+    mentorName: 'Nina Okafor',
+    amount: 100,
+    currency: 'XLM',
+    status: 'pending',
+    date: '2026-03-22T09:00:00Z',
+    stellarTxHash: 'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+    description: 'Session: DeFi Protocol Architecture on Stellar',
+    sessionId: 's3',
+    sessionTopic: 'DeFi Protocol Architecture on Stellar',
+  },
+  {
+    id: 'tx4',
+    type: 'session',
+    mentorId: 'm1',
+    mentorName: 'Dr. Sarah Chen',
+    amount: 75,
+    currency: 'XLM',
+    status: 'failed',
+    date: '2026-03-15T11:00:00Z',
+    stellarTxHash: 'd4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5',
+    description: 'Session: JavaScript SDK for Stellar',
+    sessionId: 's4',
+    sessionTopic: 'JavaScript SDK for Stellar',
+  },
+  {
+    id: 'tx5',
+    type: 'refund',
+    mentorId: 'm2',
+    mentorName: 'Alex Rivera',
+    amount: 50,
+    currency: 'XLM',
+    status: 'completed',
+    date: '2026-03-12T16:45:00Z',
+    stellarTxHash: 'e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6',
+    description: 'Refund: Cancelled session - Stellar Wallet Integration',
+    sessionId: 's5',
+    sessionTopic: 'Stellar Wallet Integration',
+  },
+  {
+    id: 'tx6',
+    type: 'session',
+    mentorId: 'm4',
+    mentorName: 'Kwame Mensah',
+    amount: 120,
+    currency: 'XLM',
+    status: 'completed',
+    date: '2026-03-10T13:30:00Z',
+    stellarTxHash: 'f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1',
+    description: 'Session: Advanced Anchor Protocols',
+    sessionId: 's6',
+    sessionTopic: 'Advanced Anchor Protocols',
+  },
+];
+
+export class RevenueReportService {
+  /**
+   * Returns transactions for the given date range and optional status filter.
+   * The return type is intentionally a union — callers must handle both shapes.
+   * When page/limit are provided, returns a paginated result; otherwise a flat array.
+   */
+  async getTransactions(params: GetTransactionsParams): Promise<GetTransactionsResult> {
+    const { from, to, status, page, limit } = params;
+
+    let results = MOCK_TRANSACTIONS.filter((tx) => {
+      const inRange = tx.date >= from && tx.date <= to + 'T23:59:59Z';
+      const matchesStatus = status ? tx.status === status : true;
+      return inRange && matchesStatus;
+    });
+
+    // Return paginated shape when pagination params are present
+    if (page !== undefined && limit !== undefined) {
+      const total = results.length;
+      const totalPages = Math.max(1, Math.ceil(total / limit));
+      const offset = (page - 1) * limit;
+      const transactions = results.slice(offset, offset + limit);
+
+      return {
+        transactions,
+        pagination: { page, limit, total, totalPages },
+      };
+    }
+
+    // Otherwise return flat array
+    return results;
+  }
+}

--- a/server/src/services/revenue-report.service.ts
+++ b/server/src/services/revenue-report.service.ts
@@ -137,8 +137,13 @@ export class RevenueReportService {
   async getTransactions(params: GetTransactionsParams): Promise<GetTransactionsResult> {
     const { from, to, status, page, limit } = params;
 
+    // Both `from` and `to` are full ISO 8601 UTC timestamps — use Date comparison
+    const fromMs = new Date(from).getTime();
+    const toMs = new Date(to).getTime();
+
     let results = MOCK_TRANSACTIONS.filter((tx) => {
-      const inRange = tx.date >= from && tx.date <= to + 'T23:59:59Z';
+      const txMs = new Date(tx.date).getTime();
+      const inRange = txMs >= fromMs && txMs <= toMs;
       const matchesStatus = status ? tx.status === status : true;
       return inRange && matchesStatus;
     });

--- a/src/components/export/ExportStatusPanel.tsx
+++ b/src/components/export/ExportStatusPanel.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import type { ExportJobStatus } from '../../hooks/useExportJob';
+
+interface ExportStatusPanelProps {
+  jobId: string | null;
+  status: ExportJobStatus;
+  error_message: string | null;
+  downloadExpired: boolean;
+  loading: boolean;
+  onStartExport: () => void;
+  onDownload: () => void;
+}
+
+// ── Spinner ───────────────────────────────────────────────────────────────────
+
+function Spinner({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      className={`animate-spin ${className}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12" cy="12" r="10"
+        stroke="currentColor" strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+      />
+    </svg>
+  );
+}
+
+// ── Progress bar (indeterminate) ──────────────────────────────────────────────
+
+function ProgressBar() {
+  return (
+    <div
+      className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden"
+      role="progressbar"
+      aria-label="Export progress"
+      aria-valuetext="Processing"
+    >
+      <div className="h-full bg-stellar rounded-full animate-[progress_1.4s_ease-in-out_infinite]" />
+    </div>
+  );
+}
+
+// ── Panel ─────────────────────────────────────────────────────────────────────
+
+const ExportStatusPanel: React.FC<ExportStatusPanelProps> = ({
+  jobId,
+  status,
+  error_message,
+  downloadExpired,
+  loading,
+  onStartExport,
+  onDownload,
+}) => {
+  // ── Download expired (overrides completed state) ──────────────────────────
+  if (downloadExpired) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-6 px-4 text-center">
+        <div className="w-10 h-10 rounded-xl bg-amber-50 flex items-center justify-center">
+          <svg className="w-5 h-5 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+          </svg>
+        </div>
+        <p className="text-sm font-semibold text-gray-700">
+          This download has expired. Please request a new export.
+        </p>
+        <button
+          onClick={onStartExport}
+          className="mt-1 px-4 py-2 rounded-xl text-xs font-bold bg-stellar text-white hover:bg-stellar-dark transition-all"
+        >
+          Request new export
+        </button>
+      </div>
+    );
+  }
+
+  // ── Initial / no job yet ──────────────────────────────────────────────────
+  if (!jobId && !loading) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-6 px-4 text-center">
+        <p className="text-sm text-gray-500">Export your transaction data as a CSV file.</p>
+        <button
+          onClick={onStartExport}
+          className="px-5 py-2.5 rounded-xl text-sm font-bold bg-stellar text-white shadow-lg shadow-stellar/20 hover:bg-stellar-dark transition-all"
+        >
+          Start export
+        </button>
+      </div>
+    );
+  }
+
+  // ── Creating job (POST in-flight) ─────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="flex items-center gap-3 py-4 px-4">
+        <Spinner className="w-4 h-4 text-stellar flex-shrink-0" />
+        <span className="text-sm text-gray-500">Starting export…</span>
+      </div>
+    );
+  }
+
+  // ── pending ───────────────────────────────────────────────────────────────
+  if (status === 'pending') {
+    return (
+      <div className="flex items-center gap-3 py-4 px-4" role="status" aria-live="polite">
+        <Spinner className="w-4 h-4 text-gray-400 flex-shrink-0" />
+        <span className="text-sm text-gray-500">Queued — waiting to start…</span>
+      </div>
+    );
+  }
+
+  // ── processing ────────────────────────────────────────────────────────────
+  if (status === 'processing') {
+    return (
+      <div className="flex flex-col gap-2 py-4 px-4" role="status" aria-live="polite">
+        <div className="flex items-center gap-3">
+          <Spinner className="w-4 h-4 text-stellar flex-shrink-0" />
+          <span className="text-sm text-gray-600 font-medium">Preparing your data…</span>
+        </div>
+        <ProgressBar />
+      </div>
+    );
+  }
+
+  // ── completed ─────────────────────────────────────────────────────────────
+  if (status === 'completed') {
+    return (
+      <div className="flex items-center justify-between gap-4 py-4 px-4" role="status" aria-live="polite">
+        <div className="flex items-center gap-2">
+          <svg className="w-4 h-4 text-emerald-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+              d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span className="text-sm font-semibold text-gray-700">Ready to download</span>
+        </div>
+        <button
+          onClick={onDownload}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-xl text-xs font-bold bg-emerald-500 text-white hover:bg-emerald-600 transition-all shadow-sm"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+              d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+          </svg>
+          Download
+        </button>
+      </div>
+    );
+  }
+
+  // ── failed ────────────────────────────────────────────────────────────────
+  return (
+    <div className="flex items-start justify-between gap-4 py-4 px-4" role="alert">
+      <div className="flex items-start gap-2">
+        <svg className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5"
+            d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+        </svg>
+        <span className="text-sm text-red-600">
+          {error_message ?? 'Export failed. Please try again.'}
+        </span>
+      </div>
+      <button
+        onClick={onStartExport}
+        className="flex-shrink-0 px-4 py-2 rounded-xl text-xs font-bold border border-red-200 text-red-600 hover:bg-red-50 transition-all"
+      >
+        Try again
+      </button>
+    </div>
+  );
+};
+
+export default ExportStatusPanel;

--- a/src/components/payment/PaymentFilters.tsx
+++ b/src/components/payment/PaymentFilters.tsx
@@ -27,6 +27,8 @@ interface RevenuePaymentFiltersProps {
   onLoad: () => void;
   loading: boolean;
   canLoad: boolean;
+  /** Inline error shown below the date pickers (e.g. from < to violation or 400 from server) */
+  dateRangeError?: string | null;
 }
 
 // ── Status dropdown options ───────────────────────────────────────────────────
@@ -46,40 +48,61 @@ export const RevenuePaymentFilters: React.FC<RevenuePaymentFiltersProps> = ({
   onLoad,
   loading,
   canLoad,
+  dateRangeError,
 }) => (
   <div className="bg-white rounded-3xl border border-gray-100 shadow-sm p-6 space-y-5">
     {/* Date range */}
-    <div className="grid grid-cols-2 gap-3">
-      <div>
-        <label
-          htmlFor="revenue-date-from"
-          className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
-        >
-          From <span className="text-red-400">*</span>
-        </label>
-        <input
-          id="revenue-date-from"
-          type="date"
-          value={filters.from}
-          onChange={(e) => onUpdateFilters({ from: e.target.value })}
-          className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
-        />
+    <div className="space-y-1.5">
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label
+            htmlFor="revenue-date-from"
+            className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
+          >
+            From <span className="text-red-400">*</span>
+          </label>
+          <input
+            id="revenue-date-from"
+            type="date"
+            value={filters.from}
+            onChange={(e) => onUpdateFilters({ from: e.target.value })}
+            aria-invalid={!!dateRangeError}
+            aria-describedby={dateRangeError ? 'date-range-error' : undefined}
+            className={`w-full px-4 py-2.5 text-sm rounded-xl border bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all ${
+              dateRangeError ? 'border-red-300' : 'border-gray-200'
+            }`}
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="revenue-date-to"
+            className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
+          >
+            To <span className="text-red-400">*</span>
+          </label>
+          <input
+            id="revenue-date-to"
+            type="date"
+            value={filters.to}
+            onChange={(e) => onUpdateFilters({ to: e.target.value })}
+            aria-invalid={!!dateRangeError}
+            className={`w-full px-4 py-2.5 text-sm rounded-xl border bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all ${
+              dateRangeError ? 'border-red-300' : 'border-gray-200'
+            }`}
+          />
+        </div>
       </div>
-      <div>
-        <label
-          htmlFor="revenue-date-to"
-          className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
+
+      {/* Inline date range error */}
+      {dateRangeError && (
+        <p
+          id="date-range-error"
+          role="alert"
+          className="text-xs text-red-500 font-medium pt-0.5"
         >
-          To <span className="text-red-400">*</span>
-        </label>
-        <input
-          id="revenue-date-to"
-          type="date"
-          value={filters.to}
-          onChange={(e) => onUpdateFilters({ to: e.target.value })}
-          className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
-        />
-      </div>
+          {dateRangeError}
+        </p>
+      )}
     </div>
 
     {/* Status dropdown */}

--- a/src/components/payment/PaymentFilters.tsx
+++ b/src/components/payment/PaymentFilters.tsx
@@ -2,16 +2,135 @@ import React from 'react';
 import type { PaymentStatus } from '../../types';
 import type { PaymentFiltersState } from '../../hooks/usePaymentHistory';
 
-interface PaymentFiltersProps {
+// ── Legacy props (used by the mock-data PaymentHistory page) ─────────────────
+
+interface LegacyPaymentFiltersProps {
   filters: PaymentFiltersState;
   onUpdateFilters: (patch: Partial<PaymentFiltersState>) => void;
   onToggleStatus: (status: PaymentStatus) => void;
   onClearFilters: () => void;
 }
 
+// ── Revenue-report props (used by the real-API PaymentHistory page) ───────────
+
+export type TransactionStatus = 'completed' | 'pending' | 'failed';
+
+export interface RevenueFiltersState {
+  from: string;
+  to: string;
+  status: TransactionStatus | '';
+}
+
+interface RevenuePaymentFiltersProps {
+  filters: RevenueFiltersState;
+  onUpdateFilters: (patch: Partial<RevenueFiltersState>) => void;
+  onLoad: () => void;
+  loading: boolean;
+  canLoad: boolean;
+}
+
+// ── Status dropdown options ───────────────────────────────────────────────────
+
+const STATUS_OPTIONS: { value: TransactionStatus | ''; label: string }[] = [
+  { value: '', label: 'All statuses' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'failed', label: 'Failed' },
+];
+
+// ── Revenue filters (new, real-API variant) ───────────────────────────────────
+
+export const RevenuePaymentFilters: React.FC<RevenuePaymentFiltersProps> = ({
+  filters,
+  onUpdateFilters,
+  onLoad,
+  loading,
+  canLoad,
+}) => (
+  <div className="bg-white rounded-3xl border border-gray-100 shadow-sm p-6 space-y-5">
+    {/* Date range */}
+    <div className="grid grid-cols-2 gap-3">
+      <div>
+        <label
+          htmlFor="revenue-date-from"
+          className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
+        >
+          From <span className="text-red-400">*</span>
+        </label>
+        <input
+          id="revenue-date-from"
+          type="date"
+          value={filters.from}
+          onChange={(e) => onUpdateFilters({ from: e.target.value })}
+          className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="revenue-date-to"
+          className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
+        >
+          To <span className="text-red-400">*</span>
+        </label>
+        <input
+          id="revenue-date-to"
+          type="date"
+          value={filters.to}
+          onChange={(e) => onUpdateFilters({ to: e.target.value })}
+          className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
+        />
+      </div>
+    </div>
+
+    {/* Status dropdown */}
+    <div>
+      <label
+        htmlFor="revenue-status"
+        className="block text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1.5"
+      >
+        Status
+      </label>
+      <select
+        id="revenue-status"
+        value={filters.status}
+        onChange={(e) =>
+          onUpdateFilters({ status: e.target.value as TransactionStatus | '' })
+        }
+        className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all appearance-none"
+      >
+        {STATUS_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+
+    {/* Load button — disabled until both dates are set */}
+    <div className="flex items-center justify-between pt-1">
+      {!canLoad && (
+        <span className="text-xs text-gray-400">Set both dates to load transactions</span>
+      )}
+      <button
+        id="load-transactions-btn"
+        onClick={onLoad}
+        disabled={!canLoad || loading}
+        className="ml-auto px-5 py-2.5 rounded-xl text-sm font-bold bg-stellar text-white shadow-lg shadow-stellar/20 hover:bg-stellar-dark transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {loading ? 'Loading…' : 'Load Transactions'}
+      </button>
+    </div>
+  </div>
+);
+
+// ── Legacy filters (kept for backward compat) ─────────────────────────────────
+
 const ALL_STATUSES: PaymentStatus[] = ['completed', 'pending', 'failed', 'refunded'];
 
-const STATUS_CONFIG: Record<PaymentStatus, { label: string; activeClass: string; dotClass: string }> = {
+const STATUS_CONFIG: Record<
+  PaymentStatus,
+  { label: string; activeClass: string; dotClass: string }
+> = {
   completed: {
     label: 'Completed',
     activeClass: 'bg-emerald-500 text-white shadow-emerald-200',
@@ -32,9 +151,14 @@ const STATUS_CONFIG: Record<PaymentStatus, { label: string; activeClass: string;
     activeClass: 'bg-sky-500 text-white shadow-sky-200',
     dotClass: 'bg-sky-400',
   },
+  processing: {
+    label: 'Processing',
+    activeClass: 'bg-blue-500 text-white shadow-blue-200',
+    dotClass: 'bg-blue-400',
+  },
 };
 
-const PaymentFilters: React.FC<PaymentFiltersProps> = ({
+const PaymentFilters: React.FC<LegacyPaymentFiltersProps> = ({
   filters,
   onUpdateFilters,
   onToggleStatus,
@@ -45,21 +169,26 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
 
   return (
     <div className="bg-white rounded-3xl border border-gray-100 shadow-sm p-6 space-y-5">
-
       {/* Search */}
       <div className="relative">
         <svg
           className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
-          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
-            d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+          />
         </svg>
         <input
           id="payment-search"
           type="text"
           value={filters.search}
-          onChange={e => onUpdateFilters({ search: e.target.value })}
+          onChange={(e) => onUpdateFilters({ search: e.target.value })}
           placeholder="Search by mentor name or TX hash…"
           className="w-full pl-11 pr-4 py-3 text-sm rounded-2xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar placeholder:text-gray-400 transition-all"
         />
@@ -75,7 +204,7 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
             id="payment-date-from"
             type="date"
             value={filters.dateFrom}
-            onChange={e => onUpdateFilters({ dateFrom: e.target.value })}
+            onChange={(e) => onUpdateFilters({ dateFrom: e.target.value })}
             className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
           />
         </div>
@@ -87,7 +216,7 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
             id="payment-date-to"
             type="date"
             value={filters.dateTo}
-            onChange={e => onUpdateFilters({ dateTo: e.target.value })}
+            onChange={(e) => onUpdateFilters({ dateTo: e.target.value })}
             className="w-full px-4 py-2.5 text-sm rounded-xl border border-gray-200 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-stellar/30 focus:border-stellar transition-all"
           />
         </div>
@@ -109,19 +238,25 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
           >
             All
           </button>
-          {ALL_STATUSES.map(status => {
+          {ALL_STATUSES.map((status) => {
             const isActive = filters.statuses.includes(status);
-            const { label, activeClass, dotClass } = STATUS_CONFIG[status];
+            const config = STATUS_CONFIG[status];
+            if (!config) return null;
+            const { label, activeClass, dotClass } = config;
             return (
               <button
                 key={status}
                 id={`filter-status-${status}`}
                 onClick={() => onToggleStatus(status)}
                 className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-xs font-bold transition-all shadow-sm ${
-                  isActive ? `${activeClass} shadow-lg` : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                  isActive
+                    ? `${activeClass} shadow-lg`
+                    : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
                 }`}
               >
-                <div className={`w-1.5 h-1.5 rounded-full ${isActive ? 'bg-white' : dotClass}`} />
+                <div
+                  className={`w-1.5 h-1.5 rounded-full ${isActive ? 'bg-white' : dotClass}`}
+                />
                 {label}
               </button>
             );
@@ -132,7 +267,12 @@ const PaymentFilters: React.FC<PaymentFiltersProps> = ({
       {/* Footer row */}
       <div className="flex items-center justify-between pt-1">
         <span className="text-xs text-gray-400 font-semibold">
-          {filters.statuses.length > 0 || filters.search || filters.dateFrom || filters.dateTo ? 'Filtered results' : 'All transactions'}
+          {filters.statuses.length > 0 ||
+          filters.search ||
+          filters.dateFrom ||
+          filters.dateTo
+            ? 'Filtered results'
+            : 'All transactions'}
         </span>
         {hasActiveFilters && (
           <button

--- a/src/hooks/useExportJob.ts
+++ b/src/hooks/useExportJob.ts
@@ -1,0 +1,170 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import api from '../services/api.client';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ExportJobStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+export interface ExportJobState {
+  jobId: string | null;
+  /** Normalised status — unknown values are coerced to 'pending' */
+  status: ExportJobStatus;
+  error_message: string | null;
+  expiresAt: string | null;
+  /** Set to true when a completed download returns 410 Gone */
+  downloadExpired: boolean;
+  loading: boolean;
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+// ── Status normaliser ─────────────────────────────────────────────────────────
+
+/**
+ * Coerces any unknown status string to a known ExportJobStatus.
+ * Per the AC: unexpected values are treated as 'pending' so polling continues.
+ */
+function normaliseStatus(raw: unknown): ExportJobStatus {
+  if (
+    raw === 'pending' ||
+    raw === 'processing' ||
+    raw === 'completed' ||
+    raw === 'failed'
+  ) {
+    return raw;
+  }
+  return 'pending';
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useExportJob() {
+  const [state, setState] = useState<ExportJobState>({
+    jobId: null,
+    status: 'pending',
+    error_message: null,
+    expiresAt: null,
+    downloadExpired: false,
+    loading: false,
+  });
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Track the jobId in a ref so the interval closure always sees the latest value
+  const jobIdRef = useRef<string | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  // Clean up on unmount
+  useEffect(() => () => stopPolling(), [stopPolling]);
+
+  const pollStatus = useCallback(async (jobId: string) => {
+    try {
+      const { data: envelope } = await api.get(`/export/${jobId}/status`);
+      const payload = (envelope?.data ?? {}) as Record<string, unknown>;
+      const status = normaliseStatus(payload?.status);
+
+      setState((prev: ExportJobState) => ({
+        ...prev,
+        status,
+        error_message: status === 'failed' ? ((payload?.error_message as string) ?? 'Export failed.') : null,
+        expiresAt: (payload?.expiresAt as string) ?? null,
+      }));
+
+      // Terminal states — stop the loop
+      if (status === 'completed' || status === 'failed') {
+        stopPolling();
+      }
+    } catch {
+      // Network hiccup — keep polling; don't surface transient errors
+    }
+  }, [stopPolling]);
+
+  /**
+   * Kick off a new export job.
+   * Resets all state, creates the job, then starts polling.
+   */
+  const startExport = useCallback(async () => {
+    stopPolling();
+
+    setState({
+      jobId: null,
+      status: 'pending',
+      error_message: null,
+      expiresAt: null,
+      downloadExpired: false,
+      loading: true,
+    });
+
+    try {
+      const { data: envelope } = await api.post('/export');
+      const jobId: string = (envelope?.data as { jobId: string })?.jobId;
+
+      if (!jobId) throw new Error('Server did not return a jobId');
+
+      jobIdRef.current = jobId;
+
+      setState((prev: ExportJobState) => ({ ...prev, jobId, loading: false }));
+
+      // Immediate first poll, then on interval
+      await pollStatus(jobId);
+
+      intervalRef.current = setInterval(() => {
+        if (jobIdRef.current) pollStatus(jobIdRef.current);
+      }, POLL_INTERVAL_MS);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start export';
+      setState((prev: ExportJobState) => ({
+        ...prev,
+        loading: false,
+        status: 'failed',
+        error_message: message,
+      }));
+    }
+  }, [pollStatus, stopPolling]);
+
+  /**
+   * Trigger the file download for a completed job.
+   * Handles 410 Gone by setting downloadExpired = true.
+   */
+  const downloadExport = useCallback(async () => {
+    const { jobId } = state;
+    if (!jobId) return;
+
+    try {
+      const response = await api.get(`/export/${jobId}/download`, {
+        responseType: 'blob',
+        // Don't let the axios interceptor auto-retry on 410
+        validateStatus: (s: number) => s < 500,
+      });
+
+      if (response.status === 410) {
+        setState((prev: ExportJobState) => ({ ...prev, downloadExpired: true }));
+        return;
+      }
+
+      // Trigger browser download
+      const blob = new Blob([response.data], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `export_${jobId}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch {
+      setState((prev: ExportJobState) => ({ ...prev, downloadExpired: true }));
+    }
+  }, [state]);
+
+  return {
+    ...state,
+    startExport,
+    downloadExport,
+  };
+}

--- a/src/hooks/useRevenueTransactions.ts
+++ b/src/hooks/useRevenueTransactions.ts
@@ -1,0 +1,116 @@
+import { useState, useCallback } from 'react';
+import api from '../services/api.client';
+import type { PaymentTransaction, PaymentStatus } from '../types/payment.types';
+
+export interface RevenueTransactionFilters {
+  from: string;
+  to: string;
+  status: PaymentStatus | '';
+}
+
+export interface RevenueTransactionsState {
+  transactions: PaymentTransaction[];
+  loading: boolean;
+  /** null means no fetch has been attempted yet */
+  error: string | null;
+  hasFetched: boolean;
+}
+
+/**
+ * Defensive data accessor.
+ *
+ * The server wraps everything in ResponseUtil.success → { success, data, meta }.
+ * The inner `data` from RevenueReportService can be:
+ *   - PaymentTransaction[]          (flat list)
+ *   - { transactions: PaymentTransaction[], pagination: {...} }  (paginated)
+ *
+ * Returns a normalised PaymentTransaction[] or throws if the shape is unrecognised.
+ */
+function extractTransactions(responseData: unknown): PaymentTransaction[] {
+  // Flat array
+  if (Array.isArray(responseData)) {
+    return responseData as PaymentTransaction[];
+  }
+
+  // Paginated object with a `transactions` key
+  if (
+    responseData !== null &&
+    typeof responseData === 'object' &&
+    'transactions' in responseData &&
+    Array.isArray((responseData as { transactions: unknown }).transactions)
+  ) {
+    return (responseData as { transactions: PaymentTransaction[] }).transactions;
+  }
+
+  throw new Error('Unexpected response shape');
+}
+
+export function useRevenueTransactions() {
+  const [state, setState] = useState<RevenueTransactionsState>({
+    transactions: [],
+    loading: false,
+    error: null,
+    hasFetched: false,
+  });
+
+  const [filters, setFilters] = useState<RevenueTransactionFilters>({
+    from: '',
+    to: '',
+    status: '',
+  });
+
+  const fetchTransactions = useCallback(
+    async (overrideFilters?: RevenueTransactionFilters) => {
+      const active = overrideFilters ?? filters;
+
+      setState((prev) => ({ ...prev, loading: true, error: null }));
+
+      try {
+        const params = new URLSearchParams({
+          from: active.from,
+          to: active.to,
+        });
+        if (active.status) params.set('status', active.status);
+
+        const { data: envelope } = await api.get(
+          `/revenue/transactions?${params.toString()}`,
+        );
+
+        // envelope = { success: true, data: <flat|paginated>, meta: {...} }
+        const transactions = extractTransactions(envelope?.data);
+
+        setState({ transactions, loading: false, error: null, hasFetched: true });
+      } catch (err: unknown) {
+        const message =
+          err instanceof Error ? err.message : 'Unable to load transaction data';
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: message,
+          hasFetched: true,
+        }));
+      }
+    },
+    [filters],
+  );
+
+  const updateFilters = useCallback((patch: Partial<RevenueTransactionFilters>) => {
+    setFilters((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const retry = useCallback(() => {
+    fetchTransactions();
+  }, [fetchTransactions]);
+
+  /** Both from and to must be set before the user can load */
+  const canFetch = filters.from.length > 0 && filters.to.length > 0;
+
+  return {
+    ...state,
+    filters,
+    updateFilters,
+    fetchTransactions,
+    retry,
+    canFetch,
+  };
+}

--- a/src/hooks/useRevenueTransactions.ts
+++ b/src/hooks/useRevenueTransactions.ts
@@ -1,9 +1,57 @@
 import { useState, useCallback } from 'react';
+import type { AxiosError } from 'axios';
 import api from '../services/api.client';
 import type { PaymentTransaction, PaymentStatus } from '../types/payment.types';
 
+// ── Date helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Convert a YYYY-MM-DD string (from <input type="date">) to the start of that
+ * day in UTC: "2025-01-01T00:00:00.000Z"
+ */
+export function toStartOfDayUTC(dateStr: string): string {
+  return `${dateStr}T00:00:00.000Z`;
+}
+
+/**
+ * Convert a YYYY-MM-DD string to the end of that day in UTC:
+ * "2025-01-31T23:59:59.999Z"
+ */
+export function toEndOfDayUTC(dateStr: string): string {
+  return `${dateStr}T23:59:59.999Z`;
+}
+
+/**
+ * Format a Date to YYYY-MM-DD for use as an <input type="date"> value.
+ */
+export function toDateInputValue(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Returns the default date range: from = now - 30 days, to = now.
+ * Values are YYYY-MM-DD strings suitable for <input type="date">.
+ */
+function defaultDateRange(): { from: string; to: string } {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - 30);
+  return {
+    from: toDateInputValue(from),
+    to: toDateInputValue(to),
+  };
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Internal filter state uses YYYY-MM-DD strings (native date input format).
+ * ISO conversion happens at fetch time.
+ */
 export interface RevenueTransactionFilters {
+  /** YYYY-MM-DD */
   from: string;
+  /** YYYY-MM-DD */
   to: string;
   status: PaymentStatus | '';
 }
@@ -11,28 +59,19 @@ export interface RevenueTransactionFilters {
 export interface RevenueTransactionsState {
   transactions: PaymentTransaction[];
   loading: boolean;
-  /** null means no fetch has been attempted yet */
+  /** null = no fetch attempted yet */
   error: string | null;
+  /** Inline error shown below the date picker (e.g. 400 validation message) */
+  dateRangeError: string | null;
   hasFetched: boolean;
 }
 
-/**
- * Defensive data accessor.
- *
- * The server wraps everything in ResponseUtil.success → { success, data, meta }.
- * The inner `data` from RevenueReportService can be:
- *   - PaymentTransaction[]          (flat list)
- *   - { transactions: PaymentTransaction[], pagination: {...} }  (paginated)
- *
- * Returns a normalised PaymentTransaction[] or throws if the shape is unrecognised.
- */
+// ── Defensive data accessor ───────────────────────────────────────────────────
+
 function extractTransactions(responseData: unknown): PaymentTransaction[] {
-  // Flat array
   if (Array.isArray(responseData)) {
     return responseData as PaymentTransaction[];
   }
-
-  // Paginated object with a `transactions` key
   if (
     responseData !== null &&
     typeof responseData === 'object' &&
@@ -41,21 +80,35 @@ function extractTransactions(responseData: unknown): PaymentTransaction[] {
   ) {
     return (responseData as { transactions: PaymentTransaction[] }).transactions;
   }
-
   throw new Error('Unexpected response shape');
 }
 
+// ── Extract inline error from a 400 response body ────────────────────────────
+
+function extract400Message(err: unknown): string | null {
+  const axiosErr = err as AxiosError<{ error?: { message?: string } }>;
+  if (axiosErr?.response?.status === 400) {
+    return axiosErr.response.data?.error?.message ?? 'Invalid date range.';
+  }
+  return null;
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
 export function useRevenueTransactions() {
+  const defaults = defaultDateRange();
+
   const [state, setState] = useState<RevenueTransactionsState>({
     transactions: [],
     loading: false,
     error: null,
+    dateRangeError: null,
     hasFetched: false,
   });
 
   const [filters, setFilters] = useState<RevenueTransactionFilters>({
-    from: '',
-    to: '',
+    from: defaults.from,
+    to: defaults.to,
     status: '',
   });
 
@@ -63,12 +116,27 @@ export function useRevenueTransactions() {
     async (overrideFilters?: RevenueTransactionFilters) => {
       const active = overrideFilters ?? filters;
 
-      setState((prev) => ({ ...prev, loading: true, error: null }));
+      // ── Client-side from < to guard ───────────────────────────────────────
+      if (active.from && active.to && active.from >= active.to) {
+        setState((prev: RevenueTransactionsState) => ({
+          ...prev,
+          dateRangeError: 'Start date must be before end date',
+        }));
+        return;
+      }
+
+      setState((prev: RevenueTransactionsState) => ({
+        ...prev,
+        loading: true,
+        error: null,
+        dateRangeError: null,
+      }));
 
       try {
+        // Convert YYYY-MM-DD → full ISO 8601 UTC timestamps before sending
         const params = new URLSearchParams({
-          from: active.from,
-          to: active.to,
+          from: toStartOfDayUTC(active.from),
+          to: toEndOfDayUTC(active.to),
         });
         if (active.status) params.set('status', active.status);
 
@@ -76,14 +144,32 @@ export function useRevenueTransactions() {
           `/revenue/transactions?${params.toString()}`,
         );
 
-        // envelope = { success: true, data: <flat|paginated>, meta: {...} }
         const transactions = extractTransactions(envelope?.data);
 
-        setState({ transactions, loading: false, error: null, hasFetched: true });
+        setState({
+          transactions,
+          loading: false,
+          error: null,
+          dateRangeError: null,
+          hasFetched: true,
+        });
       } catch (err: unknown) {
+        // 400 errors → show inline below the date picker
+        const inlineMsg = extract400Message(err);
+        if (inlineMsg) {
+          setState((prev: RevenueTransactionsState) => ({
+            ...prev,
+            loading: false,
+            dateRangeError: inlineMsg,
+            hasFetched: true,
+          }));
+          return;
+        }
+
+        // All other errors → show in the main error panel
         const message =
           err instanceof Error ? err.message : 'Unable to load transaction data';
-        setState((prev) => ({
+        setState((prev: RevenueTransactionsState) => ({
           ...prev,
           loading: false,
           error: message,
@@ -96,13 +182,15 @@ export function useRevenueTransactions() {
 
   const updateFilters = useCallback((patch: Partial<RevenueTransactionFilters>) => {
     setFilters((prev) => ({ ...prev, ...patch }));
+    if ('from' in patch || 'to' in patch) {
+      setState((prev: RevenueTransactionsState) => ({ ...prev, dateRangeError: null }));
+    }
   }, []);
 
   const retry = useCallback(() => {
     fetchTransactions();
   }, [fetchTransactions]);
 
-  /** Both from and to must be set before the user can load */
   const canFetch = filters.from.length > 0 && filters.to.length > 0;
 
   return {

--- a/src/index.css
+++ b/src/index.css
@@ -89,3 +89,18 @@
     }
   }
 }
+
+/* ── Export progress animation ── */
+@keyframes progress {
+  0% {
+    transform: translateX(-100%);
+    width: 30%;
+  }
+  50% {
+    width: 70%;
+  }
+  100% {
+    transform: translateX(400%);
+    width: 30%;
+  }
+}

--- a/src/pages/PaymentHistory.tsx
+++ b/src/pages/PaymentHistory.tsx
@@ -1,89 +1,137 @@
-import React, { useState, useEffect } from 'react';
-import { usePaymentHistory } from '../hooks/usePaymentHistory';
+import React, { useState } from 'react';
+import { useRevenueTransactions } from '../hooks/useRevenueTransactions';
+import { RevenuePaymentFilters } from '../components/payment/PaymentFilters';
 import PaymentHistoryList from '../components/payment/PaymentHistoryList';
-import PaymentFilters from '../components/payment/PaymentFilters';
 import { TransactionDetail } from '../components/payment/TransactionDetail';
 import { SkeletonCard } from '../components/animations/SkeletonLoader';
-import { useMinimumLoading } from '../hooks/useMinimumLoading';
 import { generatePaymentReceipt } from '../utils/pdf-receipt';
 import { retryPayment } from '../services/payment.service';
 import type { PaymentTransaction } from '../types';
 
+// ── Loading skeleton ──────────────────────────────────────────────────────────
+
+const TransactionSkeleton: React.FC = () => (
+  <div className="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm">
+    <div className="h-5 w-40 bg-gray-100 rounded animate-pulse mb-6" />
+    <div className="space-y-3">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <SkeletonCard key={i} variant="history" />
+      ))}
+    </div>
+  </div>
+);
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+const TransactionError: React.FC<{ message: string; onRetry: () => void }> = ({
+  message,
+  onRetry,
+}) => (
+  <div className="flex flex-col items-center justify-center py-16 px-6 text-center bg-white rounded-3xl border border-gray-100 shadow-sm">
+    <div className="w-14 h-14 bg-red-50 rounded-2xl flex items-center justify-center mb-4">
+      <svg
+        className="w-7 h-7 text-red-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+          d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+        />
+      </svg>
+    </div>
+    <h3 className="text-sm font-bold text-gray-700 mb-1">Unable to load transaction data</h3>
+    <p className="text-xs text-gray-400 mb-5 max-w-xs">{message}</p>
+    <button
+      onClick={onRetry}
+      className="px-5 py-2.5 rounded-xl text-sm font-bold bg-stellar text-white shadow-lg shadow-stellar/20 hover:bg-stellar-dark transition-all"
+    >
+      Retry
+    </button>
+  </div>
+);
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
 const PaymentHistory: React.FC = () => {
   const {
     transactions,
-    analytics,
+    loading,
+    error,
+    hasFetched,
     filters,
-    sortField,
-    sortDirection,
-    currentPage,
-    totalPages,
-    totalResults,
     updateFilters,
-    toggleStatusFilter,
-    clearFilters,
-    handleSort,
-    setCurrentPage,
-  } = usePaymentHistory();
+    fetchTransactions,
+    retry,
+    canFetch,
+  } = useRevenueTransactions();
 
-  const [isLoading, setIsLoading] = useState(true);
-  
-  useEffect(() => {
-    const timer = setTimeout(() => setIsLoading(false), 1000);
-    return () => clearTimeout(timer);
-  }, []);
+  const [selectedTransaction, setSelectedTransaction] =
+    useState<PaymentTransaction | null>(null);
 
-  const showSkeleton = useMinimumLoading(isLoading, 300);
-
-  const [selectedTransaction, setSelectedTransaction] = useState<PaymentTransaction | null>(null);
-
-  const handleTransactionClick = (transaction: PaymentTransaction) => {
-    setSelectedTransaction(transaction);
-  };
-
-  const handleCloseDetail = () => {
-    setSelectedTransaction(null);
-  };
+  const handleTransactionClick = (tx: PaymentTransaction) => setSelectedTransaction(tx);
+  const handleCloseDetail = () => setSelectedTransaction(null);
 
   const handleDownloadReceipt = (transactionId: string) => {
-    // In a real app, you'd fetch the full transaction details from the API
-    // For now, we'll use the transaction from the list
-    const transaction = transactions.find(tx => tx.id === transactionId);
-    if (transaction) {
-      // Mock full breakdown data - in real app this would come from API
-      const receiptData = {
-        ...transaction,
-        fullBreakdown: {
-          baseAmount: transaction.amount,
-          platformFeePercentage: 5,
-          platformFeeAmount: transaction.amount * 0.05,
-          networkFeeAmount: 0.00001,
-          totalDeductions: transaction.amount * 0.05 + 0.00001,
-          netAmount: transaction.amount - (transaction.amount * 0.05 + 0.00001),
-        },
-        stellarDetails: {
-          transactionHash: transaction.stellarTxHash,
-          ledgerSequence: Math.floor(Math.random() * 1000000),
-          timestamp: transaction.date,
-          horizonUrl: `https://horizon-testnet.stellar.org/transactions/${transaction.stellarTxHash}`,
-        },
-      };
+    const tx = transactions.find((t) => t.id === transactionId);
+    if (!tx) return;
 
-      generatePaymentReceipt(receiptData);
-    }
+    const receiptData = {
+      ...tx,
+      fullBreakdown: {
+        baseAmount: tx.amount,
+        platformFeePercentage: 5,
+        platformFeeAmount: tx.amount * 0.05,
+        networkFeeAmount: 0.00001,
+        totalDeductions: tx.amount * 0.05 + 0.00001,
+        netAmount: tx.amount - (tx.amount * 0.05 + 0.00001),
+      },
+      stellarDetails: {
+        transactionHash: tx.stellarTxHash,
+        ledgerSequence: 0,
+        timestamp: tx.date,
+        horizonUrl: `https://horizon-testnet.stellar.org/transactions/${tx.stellarTxHash}`,
+      },
+    };
+    generatePaymentReceipt(receiptData);
   };
 
   const handleRetryPayment = async (transactionId: string) => {
     try {
       await retryPayment(transactionId);
-      // In a real app, you'd refresh the data or show a success message
-      alert('Payment retry initiated successfully');
       setSelectedTransaction(null);
-    } catch (error) {
-      console.error('Failed to retry payment:', error);
-      alert('Failed to retry payment. Please try again.');
+    } catch (err) {
+      console.error('Failed to retry payment:', err);
     }
   };
+
+  // Derive analytics from the loaded transactions
+  const analytics = transactions.reduce(
+    (acc, tx) => {
+      acc.transactionCount += 1;
+      if (tx.status === 'completed') {
+        acc.totalCompleted += tx.amount;
+        acc.totalSpent += tx.amount;
+      } else if (tx.status === 'pending') {
+        acc.totalPending += tx.amount;
+        acc.totalSpent += tx.amount;
+      } else if (tx.status === 'failed') {
+        acc.totalFailed += tx.amount;
+      }
+      return acc;
+    },
+    {
+      totalSpent: 0,
+      totalCompleted: 0,
+      totalPending: 0,
+      totalRefunded: 0,
+      totalFailed: 0,
+      transactionCount: 0,
+    },
+  );
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -96,37 +144,55 @@ const PaymentHistory: React.FC = () => {
 
         {/* Filters */}
         <div className="mb-6">
-          <PaymentFilters
+          <RevenuePaymentFilters
             filters={filters}
             onUpdateFilters={updateFilters}
-            onToggleStatus={toggleStatusFilter}
-            onClearFilters={clearFilters}
+            onLoad={fetchTransactions}
+            loading={loading}
+            canLoad={canFetch}
           />
         </div>
 
-        {/* Payment History List */}
-        {showSkeleton ? (
-          <div className="space-y-4">
-            <div className="bg-white rounded-3xl p-6 border border-gray-100 shadow-sm">
-              <div className="h-6 w-48 bg-gray-100 rounded animate-pulse mb-6" />
-              <div className="space-y-3">
-                {[1, 2, 3, 4, 5].map(i => <SkeletonCard key={i} variant="history" />)}
-              </div>
-            </div>
-          </div>
-        ) : (
+        {/* Content area */}
+        {loading ? (
+          <TransactionSkeleton />
+        ) : error ? (
+          <TransactionError message={error} onRetry={retry} />
+        ) : hasFetched ? (
           <PaymentHistoryList
-             transactions={transactions}
-             analytics={analytics}
-             sortField={sortField}
-             sortDirection={sortDirection}
-             currentPage={currentPage}
-             totalPages={totalPages}
-             totalResults={totalResults}
-             onSort={handleSort}
-             onPageChange={setCurrentPage}
-             onSelectTransaction={handleTransactionClick}
-            />
+            transactions={transactions}
+            analytics={analytics}
+            sortField="date"
+            sortDirection="desc"
+            currentPage={1}
+            totalPages={1}
+            totalResults={transactions.length}
+            onSort={() => {}}
+            onPageChange={() => {}}
+            onSelectTransaction={handleTransactionClick}
+          />
+        ) : (
+          /* Initial state — user hasn't loaded yet */
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <div className="w-14 h-14 bg-gray-100 rounded-2xl flex items-center justify-center mb-4">
+              <svg
+                className="w-7 h-7 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                />
+              </svg>
+            </div>
+            <p className="text-sm font-semibold text-gray-500">
+              Select a date range and click "Load Transactions"
+            </p>
+          </div>
         )}
 
         {/* Transaction Detail Modal */}

--- a/src/pages/PaymentHistory.tsx
+++ b/src/pages/PaymentHistory.tsx
@@ -61,6 +61,7 @@ const PaymentHistory: React.FC = () => {
     transactions,
     loading,
     error,
+    dateRangeError,
     hasFetched,
     filters,
     updateFilters,
@@ -150,6 +151,7 @@ const PaymentHistory: React.FC = () => {
             onLoad={fetchTransactions}
             loading={loading}
             canLoad={canFetch}
+            dateRangeError={dateRangeError}
           />
         </div>
 


### PR DESCRIPTION
Fixes the date format mismatch between the frontend date picker and the revenue report endpoint, adds proper range validation, and surfaces server errors inline rather than as a toast.

Backend

The controller's Zod schema now requires full ISO 8601 UTC timestamps instead of bare date strings. A cross-field refine check enforces from < to and returns a clear message the frontend can display directly. The 400 response shape exposes error.message at the top level for easy consumption. The service's date comparison was also corrected — it now uses Date.getTime() instead of lexicographic string comparison with a manually appended T23:59:59Z.

Frontend

The hook now owns all date formatting logic. It stores YYYY-MM-DD strings internally (native date input format) and converts to full ISO timestamps at fetch time — from becomes T00:00:00.000Z, to becomes T23:59:59.999Z. On page load the default range is the last 30 days. A client-side guard checks from >= to before any request fires and sets a dateRangeError immediately. When the server returns a 400, extract400Message reads response.data.error.message and routes it to dateRangeError — not the main error panel, not a toast. Editing either date field clears the error automatically.

closes #370 