### PR TITLE
feat: show health banner on 503 without throwing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import SkipNavigation from './components/a11y/SkipNavigation';
 import LoadingAnimation from './components/animations/LoadingAnimation';
 import OAuthCallback from './components/auth/OAuthCallback';
 import AuthErrorPage from './pages/AuthErrorPage';
+import HealthBanner from './components/ui/HealthBanner';
 
 // Lazy load pages for code splitting
 const LandingPage = lazy(() => import('./pages/LandingPage'));
@@ -52,6 +53,7 @@ function AppRoutes() {
   return (
     <BrowserRouter>
       <SkipNavigation />
+      <HealthBanner />
       <main id="main-content">
         <Suspense fallback={<PageLoader />}>
           <Routes>

--- a/src/components/ui/HealthBanner.tsx
+++ b/src/components/ui/HealthBanner.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useHealthStatus, ComponentStatus } from '../../hooks/useHealthStatus';
+
+const COMPONENT_MESSAGES: Record<string, string> = {
+  horizon: 'Payment processing is temporarily unavailable.',
+  db: 'Database access is temporarily unavailable.',
+  redis: 'Some caching features may be affected.',
+};
+
+function getAffectedMessages(components: Record<string, ComponentStatus>): string[] {
+  return Object.entries(components)
+    .filter(([, status]) => status !== 'healthy')
+    .map(([key]) => COMPONENT_MESSAGES[key] ?? `${key} is temporarily unavailable.`);
+}
+
+export default function HealthBanner() {
+  const health = useHealthStatus();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!health || dismissed) return null;
+
+  const isUnhealthy = health.status === 'unhealthy';
+  const affectedMessages = getAffectedMessages(health.components ?? {});
+
+  const bannerClass = isUnhealthy
+    ? 'bg-red-50 border-red-300 text-red-800'
+    : 'bg-yellow-50 border-yellow-300 text-yellow-800';
+
+  const headline = isUnhealthy
+    ? "Some services are currently experiencing issues. We're working on it."
+    : 'Some features may be temporarily unavailable.';
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className={`w-full border-b px-4 py-3 text-sm ${bannerClass}`}
+    >
+      <div className="flex items-start justify-between gap-4 max-w-7xl mx-auto">
+        <div>
+          <p className="font-medium">{headline}</p>
+          {affectedMessages.length > 0 && (
+            <ul className="mt-1 list-disc list-inside space-y-0.5 opacity-90">
+              {affectedMessages.map((msg) => (
+                <li key={msg}>{msg}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <button
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss banner"
+          className="shrink-0 opacity-60 hover:opacity-100 text-lg leading-none"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useHealthStatus.ts
+++ b/src/hooks/useHealthStatus.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+export type ComponentStatus = 'healthy' | 'unhealthy' | 'degraded';
+
+export interface HealthStatus {
+  status: 'healthy' | 'unhealthy' | 'degraded';
+  components: Record<string, ComponentStatus>;
+}
+
+export function useHealthStatus(): HealthStatus | null {
+  const [health, setHealth] = useState<HealthStatus | null>(null);
+
+  useEffect(() => {
+    axios
+      .get<HealthStatus>('/api/health/ready', { validateStatus: () => true })
+      .then((res) => {
+        const data = res.data;
+        if (data?.status && data.status !== 'healthy') {
+          setHealth(data);
+        }
+      })
+      .catch(() => {
+        // Network failure — don't show banner; monitoring handles this
+      });
+  }, []);
+
+  return health;
+}


### PR DESCRIPTION
closes #363 GET /health/ready Returns 503 When Unhealthy — Frontend Must Handle This Without Showing an Error Page