### PR TITLE
fix: handle Zod field error shape in parseApiError, silence presence 422

### DIFF
--- a/src/__tests__/parseApiError.test.ts
+++ b/src/__tests__/parseApiError.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { AxiosError, AxiosResponse } from "axios";
-import { parseApiError } from "../../utils/parse.api.error";
+import { parseApiError } from "../utils/parse.api.error";
 
 function makeError(
   status: number,
@@ -66,5 +66,21 @@ describe("parseApiError", () => {
   it("returns fallback message when response is undefined", () => {
     const err = { response: undefined, isAxiosError: true } as unknown as AxiosError;
     expect(parseApiError(err)).toBe("An unexpected error occurred.");
+  });
+
+  // Zod field error shape: { errors: { userIds: ["..."] } }
+  it("extracts userIds error from Zod field error shape (POST /users/online-status)", () => {
+    const err = makeError(422, { errors: { userIds: ["Maximum 100 userIds per request"] } });
+    expect(parseApiError(err)).toBe("Maximum 100 userIds per request");
+  });
+
+  it("extracts message error from Zod field error shape", () => {
+    const err = makeError(422, { errors: { message: ["Invalid request body"] } });
+    expect(parseApiError(err)).toBe("Invalid request body");
+  });
+
+  it("prefers userIds over message in Zod field error shape", () => {
+    const err = makeError(422, { errors: { userIds: ["Too many userIds"], message: ["Other error"] } });
+    expect(parseApiError(err)).toBe("Too many userIds");
   });
 });

--- a/src/services/presence.service.ts
+++ b/src/services/presence.service.ts
@@ -1,6 +1,8 @@
 import { apiConfig } from "../config/api.config";
 import type { RequestOptions } from "../types/api.types";
 import { request } from "../utils/request.utils";
+import { parseApiError } from "../utils/parse.api.error";
+import type { AxiosError } from "axios";
 
 export interface PresenceStatus {
   userId: string;
@@ -13,12 +15,23 @@ export default class PresenceService {
     const params = new URLSearchParams();
     userIds.forEach(id => params.append('userIds', id));
 
-    return request<PresenceStatus[]>(
-      {
-        method: "GET",
-        url: `${apiConfig.url.presence}/batch?${params.toString()}`,
-      },
-      opts,
-    );
+    try {
+      return await request<PresenceStatus[]>(
+        {
+          method: "GET",
+          url: `${apiConfig.url.presence}/batch?${params.toString()}`,
+        },
+        opts,
+      );
+    } catch (err) {
+      const axiosErr = err as AxiosError;
+      if (axiosErr?.response?.status === 422) {
+        // 422 from batch presence endpoint is a Zod validation error (e.g. too many userIds).
+        // Treat as silent — presence failures should not surface to the user.
+        console.warn("[PresenceService] 422 validation error:", parseApiError(axiosErr));
+        return [];
+      }
+      throw err;
+    }
   }
 }

--- a/src/utils/parse.api.error.ts
+++ b/src/utils/parse.api.error.ts
@@ -2,11 +2,13 @@ import type { AxiosError, AxiosResponse } from "axios";
 
 /**
  * Extracts a user-friendly error message from any known API error response shape:
- *   { success: false, error: "..." }       — AuthController, PaymentsController
- *   { error: "..." }                        — DisputesController
- *   { status: "error", message: "..." }    — rate-limiter middleware
- *   { details: [{ message: "..." }] }      — Zod validation errors
- *   response.statusText                    — fallback
+ *   { success: false, error: "..." }                    — AuthController, PaymentsController
+ *   { error: "..." }                                     — DisputesController
+ *   { status: "error", message: "..." }                 — rate-limiter middleware
+ *   { details: [{ message: "..." }] }                   — Zod validation errors (array shape)
+ *   { errors: { userIds: ["..."] } }                    — Zod field errors (POST /users/online-status)
+ *   { errors: { message: ["..."] } }                    — other Zod field errors
+ *   response.statusText                                  — fallback
  */
 export function parseApiError(error: AxiosError): string {
   const response = error.response as AxiosResponse<any> | undefined;
@@ -47,6 +49,9 @@ export function parseApiError(error: AxiosError): string {
   if (data?.error) return data.error;
   if (data?.message) return data.message;
   if (data?.details?.[0]?.message) return data.details[0].message;
+  // Zod field error shape: { errors: { userIds: ["..."] } } or { errors: { message: ["..."] } }
+  if (data?.errors?.userIds?.[0]) return data.errors.userIds[0];
+  if (data?.errors?.message?.[0]) return data.errors.message[0];
   if (response?.statusText) return response.statusText;
 
   return "An unexpected error occurred.";


### PR DESCRIPTION
## Summary

Fixes #374

The batch presence endpoint (`POST /users/online-status`) uses Zod validation and returns 422 with a different error shape than all other endpoints:

```json
{ "errors": { "userIds": ["Maximum 100 userIds per request"] } }
```

This PR updates the frontend to handle this correctly.

## Changes

### `src/utils/parse.api.error.ts`
- Added handling for Zod field error shapes:
  - `response.data?.errors?.userIds?.[0]` — for the batch presence endpoint
  - `response.data?.errors?.message?.[0]` — for other Zod field errors

### `src/services/presence.service.ts`
- Wrapped `getBatchStatus` in try/catch
- 422 responses are caught silently: logs `console.warn` and returns `[]`
- All other errors are re-thrown as before

### `src/__tests__/parseApiError.test.ts`
- Fixed pre-existing broken import path (`../../utils` → `../utils`)
- Added 3 new tests covering the Zod field error shape

## Tests

All 14 tests pass (`npx vitest run src/__tests__/parseApiError.test.ts`)