### PR TITLE
fix: handle export download 500 errors gracefully

### DIFF
--- a/src/hooks/useExportDownload.ts
+++ b/src/hooks/useExportDownload.ts
@@ -1,0 +1,49 @@
+import { useState, useCallback } from "react";
+import { downloadExport } from "../services/export.service";
+
+export type DownloadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success" }
+  | { status: "error"; message: string; maySucceedOnRetry: boolean; instanceHeader: string | null };
+
+/**
+ * Hook for downloading an export file by jobId.
+ *
+ * Handles 500 gracefully — does NOT auto-retry on 500.
+ * Exposes `maySucceedOnRetry` so the UI can suggest trying again
+ * when X-Export-Instance header is present (round-robin routing).
+ */
+export function useExportDownload() {
+  const [state, setState] = useState<DownloadState>({ status: "idle" });
+
+  const download = useCallback(async (jobId: string) => {
+    setState({ status: "loading" });
+
+    const result = await downloadExport(jobId);
+
+    if (!result.ok) {
+      setState({
+        status: "error",
+        message: result.message,
+        maySucceedOnRetry: result.maySucceedOnRetry,
+        instanceHeader: result.instanceHeader,
+      });
+      return;
+    }
+
+    // Trigger browser download
+    const url = URL.createObjectURL(result.blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = result.filename;
+    a.click();
+    URL.revokeObjectURL(url);
+
+    setState({ status: "success" });
+  }, []);
+
+  const reset = useCallback(() => setState({ status: "idle" }), []);
+
+  return { state, download, reset };
+}

--- a/src/services/export.service.ts
+++ b/src/services/export.service.ts
@@ -1,0 +1,84 @@
+import type { AxiosError } from "axios";
+import api from "./api.client";
+
+export interface ExportDownloadResult {
+  ok: true;
+  blob: Blob;
+  filename: string;
+  instanceHeader: string | null;
+}
+
+export interface ExportDownloadError {
+  ok: false;
+  status: number;
+  message: string;
+  /** Present when the server returned X-Export-Instance — suggests retrying may hit the right instance */
+  instanceHeader: string | null;
+  /** True when the error is a 500 that may be instance-routing related */
+  maySucceedOnRetry: boolean;
+}
+
+export type ExportDownloadOutcome = ExportDownloadResult | ExportDownloadError;
+
+/**
+ * Download an export file for a given jobId.
+ * GET /export/:jobId/download
+ *
+ * Handles 500 gracefully: returns an error object instead of throwing,
+ * so the caller can show a specific message and a "Request New Export" button.
+ * Does NOT retry on 500 — the api.client retries are bypassed via validateStatus.
+ */
+export async function downloadExport(jobId: string): Promise<ExportDownloadOutcome> {
+  let instanceHeader: string | null = null;
+
+  try {
+    const response = await api.get<Blob>(`/export/${jobId}/download`, {
+      responseType: "blob",
+      // Prevent the api.client interceptor from retrying 5xx for this endpoint
+      validateStatus: (status) => status < 500,
+    });
+
+    instanceHeader = response.headers?.["x-export-instance"] ?? null;
+
+    if (response.status !== 200) {
+      return {
+        ok: false,
+        status: response.status,
+        message: "Download failed. The export file may no longer be available. Please request a new export.",
+        instanceHeader,
+        maySucceedOnRetry: false,
+      };
+    }
+
+    const disposition = response.headers?.["content-disposition"] ?? "";
+    const match = disposition.match(/filename[^;=\n]*=(['"]?)([^'";\n]+)\1/);
+    const filename = match?.[2] ?? `export-${jobId}.zip`;
+
+    return { ok: true, blob: response.data, filename, instanceHeader };
+  } catch (err) {
+    const axiosErr = err as AxiosError;
+    const status = axiosErr.response?.status ?? 0;
+    instanceHeader = (axiosErr.response?.headers as Record<string, string>)?.["x-export-instance"] ?? null;
+
+    // 500 — file not found on this instance (multi-instance deployment issue)
+    if (status === 500) {
+      console.error("[exportService] 500 on download", { jobId, instanceHeader });
+
+      return {
+        ok: false,
+        status: 500,
+        message: "Download failed. The export file may no longer be available. Please request a new export.",
+        instanceHeader,
+        maySucceedOnRetry: instanceHeader !== null,
+      };
+    }
+
+    return {
+      ok: false,
+      status,
+      message: "Download failed. Please try again.",
+      instanceHeader,
+      maySucceedOnRetry: false,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #376 

`ExportController.downloadExport` uses `res.download(job.file_path)` which is a local disk path. In multi-instance deployments, if the download request hits a different instance than the one that processed the job, it throws `ENOENT` and returns a 500. This PR handles that gracefully on the frontend.

## Changes

### `src/services/export.service.ts`
- `downloadExport(jobId)` returns a typed result object instead of throwing
- Uses `validateStatus: (s) => s < 500` to bypass the api.client 5xx retry interceptor — no auto-retry on 500
- On 500: returns `{ ok: false, message: "Download failed. The export file may no longer be available. Please request a new export.", maySucceedOnRetry, instanceHeader }`
- Checks `X-Export-Instance` response header — sets `maySucceedOnRetry: true` when present (round-robin may hit the correct instance on next attempt)
- Logs to console.error with jobId for debugging

### `src/hooks/useExportDownload.ts`
- Exposes `state` (`idle | loading | success | error`), `download(jobId)`, and `reset()`
- Error state includes `message`, `maySucceedOnRetry`, and `instanceHeader` for the UI to show the correct message and a "Request New Export" button